### PR TITLE
Cache functionality. Tests

### DIFF
--- a/openedx/core/djangoapps/edx_global_analytics/tasks.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tasks.py
@@ -11,13 +11,9 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from xmodule.modulestore.django import modulestore
 
-
-from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import (
-    get_cache_week_key,
-    get_cache_month_key,
-)
+from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import get_cache_week_key, get_cache_month_key
 from openedx.core.djangoapps.edx_global_analytics.utils.token_utils import get_acceptor_api_access_token
-from openedx.core.djangoapps.edx_global_analytics.utils.utils import (
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import (
     fetch_instance_information,
     get_previous_day_start_and_end_dates,
     get_previous_week_start_and_end_dates,

--- a/openedx/core/djangoapps/edx_global_analytics/tasks.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tasks.py
@@ -13,8 +13,8 @@ from xmodule.modulestore.django import modulestore
 
 
 from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import (
-    cache_timeout_week,
-    cache_timeout_month,
+    get_cache_week_key,
+    get_cache_month_key,
 )
 from openedx.core.djangoapps.edx_global_analytics.utils.token_utils import get_acceptor_api_access_token
 from openedx.core.djangoapps.edx_global_analytics.utils.utils import (
@@ -36,18 +36,15 @@ def paranoid_level_statistics_bunch():
     for day, week and month.
     """
     active_students_amount_day = fetch_instance_information(
-        'active_students_amount_day', 'active_students_amount',
-        get_previous_day_start_and_end_dates(), cache_timeout=None
+        'active_students_amount', get_previous_day_start_and_end_dates(), name_to_cache=None
     )
 
     active_students_amount_week = fetch_instance_information(
-        'active_students_amount_week', 'active_students_amount',
-        get_previous_week_start_and_end_dates(), cache_timeout_week()
+        'active_students_amount', get_previous_week_start_and_end_dates(), name_to_cache=get_cache_week_key()
     )
 
     active_students_amount_month = fetch_instance_information(
-        'active_students_amount_month', 'active_students_amount',
-        get_previous_month_start_and_end_dates(), cache_timeout_month()
+        'active_students_amount', get_previous_month_start_and_end_dates(), name_to_cache=get_cache_month_key()
     )
 
     return active_students_amount_day, active_students_amount_week, active_students_amount_month
@@ -58,8 +55,7 @@ def enthusiast_level_statistics_bunch():
     Gather particular bunch of instance data called `Enthusiast`, that contains students per country amount.
     """
     students_per_country = fetch_instance_information(
-        'students_per_country', 'students_per_country',
-        get_previous_day_start_and_end_dates(), cache_timeout=None
+        'students_per_country', get_previous_day_start_and_end_dates(), name_to_cache=None,
     )
 
     return students_per_country

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage.py
@@ -9,7 +9,7 @@ import uuid
 from ddt import ddt, data, unpack
 from mock import patch, call
 
-from openedx.core.djangoapps.edx_global_analytics.utils.utils import send_instance_statistics_to_acceptor
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import send_instance_statistics_to_acceptor
 from openedx.core.djangoapps.edx_global_analytics.utils.token_utils import (
     access_token_authorization,
     access_token_registration,
@@ -17,7 +17,7 @@ from openedx.core.djangoapps.edx_global_analytics.utils.token_utils import (
 
 
 @ddt
-@patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.requests.post')
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.requests.post')
 class TestAcceptorApiUsage(unittest.TestCase):
     """
     Test functionality for acceptor API usage.
@@ -46,7 +46,7 @@ class TestAcceptorApiUsage(unittest.TestCase):
 
         self.assertEqual(mock_request.call_args_list, expected_calls)
 
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.logging.Logger.info')
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.logging.Logger.info')
     @data(
         [httplib.CREATED, 'Data were successfully transferred to OLGA acceptor. Status code is {0}.'],
         [httplib.BAD_REQUEST, 'Data were not successfully transferred to OLGA acceptor. Status code is {0}.']

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage.py
@@ -46,12 +46,13 @@ class TestAcceptorApiUsage(unittest.TestCase):
 
         self.assertEqual(mock_request.call_args_list, expected_calls)
 
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.logging.Logger.info')
+
     @data(
         [httplib.CREATED, 'Data were successfully transferred to OLGA acceptor. Status code is {0}.'],
         [httplib.BAD_REQUEST, 'Data were not successfully transferred to OLGA acceptor. Status code is {0}.']
     )
     @unpack
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.logging.Logger.info')
     def test_sent_statistics(self, status_code, log_message, mock_logging, mock_request):
         """
         Verify that send_instance_statistics_to_acceptor successfully dispatches statistics to acceptor API.

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage_helpers.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage_helpers.py
@@ -19,7 +19,7 @@ class TestAcceptorApiUsageHelpFunctions(unittest.TestCase):
     Tests for OLGA acceptor api usage by edX global analytics application tasks and helper functions.
     """
 
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.request_exception_handler_with_logger')
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.request_exception_handler_with_logger')
     def test_decorator_if_no_exception(self, mock_request_exception_handler_with_logger):
         """
         Test request_exception_handler_with_logger return wrapped function, if Request Exception does not exist.
@@ -36,8 +36,8 @@ class TestAcceptorApiUsageHelpFunctions(unittest.TestCase):
 
         self.assertEqual(mock_decorated_function('mock'), result)
 
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.logging.Logger.exception')
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.request_exception_handler_with_logger')
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.logging.Logger.exception')
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.request_exception_handler_with_logger')
     def test_decorator_if_exception(self, mock_request_exception_handler_with_logger, mock_logging_exception):
         """
         Test request_exception_handler_with_logger log exception if whatever happened with request.

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py
@@ -2,100 +2,70 @@
 Tests for edX global analytics application cache functionality.
 """
 
-from datetime import date, datetime
+from datetime import date
 
 from mock import patch
 
 from django.test import TestCase
-from django.utils import timezone
-from django.db.models import Q
 
-from student.models import UserProfile
-from student.tests.factories import UserFactory
-
-from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import (
-    cache_instance_data,
-    cache_timeout_month,
-    cache_timeout_week,
-)
+from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import cache_instance_data, get_cache_week_key, get_cache_month_key
 
 
+
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.cache')
 class TestCacheInstanceData(TestCase):
     """
-    Test cover cache-functionality for queries results.
+    Tests for cache instance data method.
     """
 
-
-    @staticmethod
-    def create_default_data():
+    def test_cache_query_does_not_exists(self, mock_cache):
         """
-        Default integration database data for cache instance information tests.
+        Verify that cache_instance_data method return cached query result if it exists in cache.
         """
-        users_last_login = [
-            timezone.make_aware(datetime(2017, 5, 8, 0, 0, 0), timezone.get_default_timezone()),
-            timezone.make_aware(datetime(2017, 5, 14, 23, 59, 59), timezone.get_default_timezone()),
-            timezone.make_aware(datetime(2017, 5, 15, 0, 0, 0), timezone.get_default_timezone()),
-            timezone.make_aware(datetime(2017, 5, 15, 0, 0, 1), timezone.get_default_timezone())
-        ]
+        mock_cache.get.return_value = True
+        cache_instance_data('name_to_cache', 'query_result')
 
-        for user_last_login in users_last_login:
-            UserFactory(last_login=user_last_login)
+        mock_cache.set.assert_not_called()
 
-    def test_cache_new_instance_data(self):
+    def test_cache_query_exists(self, mock_cache):
         """
-        Verify that cache_instance_data returns data as expected after caching it.
+        Verify that cache_instance_data method set query result if it does not exists in cache.
         """
-        self.create_default_data()
+        mock_cache.get.return_value = None
 
-        period_start, period_end = date(2017, 5, 8), date(2017, 5, 15)
+        cache_instance_data('name_to_cache', 'query_result')
 
-        active_students_amount_week = UserProfile.objects.exclude(
-            Q(user__last_login=None) | Q(user__is_active=False)
-        ).filter(user__last_login__gte=period_start, user__last_login__lt=period_end).count()
-
-        cache_timeout = None
-
-        result = cache_instance_data('active_students_amount_week', active_students_amount_week, cache_timeout)
-
-        self.assertEqual(result, 2)
-
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.cache.get')
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.cache.set')
-    def test_returning_existed_query_result(self, mock_cache_set, mock_cache_get):
-        """
-        Verify that cache_instance_data returns data as expected if it already exists in cache.
-        """
-        mock_cache_get.return_value = 'mock_cached_query_result'
-
-        cache_instance_data('None', None, None)
-
-        self.assertEqual(0, mock_cache_set.call_count)
+        mock_cache.set.assert_called_once_with('name_to_cache', 'query_result')
 
 
-@patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.datetime')
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.date')
 class TestCacheInstanceDataHelpFunctions(TestCase):
     """
     Tests for cache help functions.
     """
 
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.date')
-    def test_cache_timeout_week(self, mock_date, mock_datetime):
+    def test_cache_timeout_week(self, mock_date):
         """
-        Verify cache_timeout_week returns correct cache timeout seconds.
+        Verify that get_cache_week_key returns correct cache key.
+
+        9 January is a monday, it is second week from year's start.
+        get_cache_week_key returns previous week `year` and `week` numbers.
         """
-        mock_datetime.now.return_value = datetime(2017, 7, 9, 23, 55, 0)
-        mock_date.today.return_value = date(2017, 7, 9)
+        mock_date.today.return_value = date(2017, 1, 9)
 
-        result = cache_timeout_week()
+        result = get_cache_week_key()
 
-        self.assertEqual(299, result)
+        self.assertEqual('2017-1-week', result)
 
-    def test_cache_timeout_month(self, mock_datetime):
+    def test_cache_timeout_month(self, mock_date):
         """
-        Verify cache_timeout_week returns correct cache timeout seconds.
+        Verify that get_cache_month_key returns correct cache key.
+
+        4th month is an April.
+        get_cache_month_key returns previous month `year` and `month` numbers.
         """
-        mock_datetime.now.return_value = datetime(2017, 7, 31, 21, 59, 59)
+        mock_date.today.return_value = date(2017, 4, 9)
 
-        result = cache_timeout_month()
+        result = get_cache_month_key()
 
-        self.assertEqual(7200, result)
+        self.assertEqual('2017-3-month', result)

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py
@@ -1,0 +1,101 @@
+"""
+Tests for edX global analytics application cache functionality.
+"""
+
+from datetime import date, datetime
+
+from mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+from django.db.models import Q
+
+from student.models import UserProfile
+from student.tests.factories import UserFactory
+
+from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import (
+    cache_instance_data,
+    cache_timeout_month,
+    cache_timeout_week,
+)
+
+
+class TestCacheInstanceData(TestCase):
+    """
+    Test cover cache-functionality for queries results.
+    """
+
+
+    @staticmethod
+    def create_default_data():
+        """
+        Default integration database data for cache instance information tests.
+        """
+        users_last_login = [
+            timezone.make_aware(datetime(2017, 5, 8, 0, 0, 0), timezone.get_default_timezone()),
+            timezone.make_aware(datetime(2017, 5, 14, 23, 59, 59), timezone.get_default_timezone()),
+            timezone.make_aware(datetime(2017, 5, 15, 0, 0, 0), timezone.get_default_timezone()),
+            timezone.make_aware(datetime(2017, 5, 15, 0, 0, 1), timezone.get_default_timezone())
+        ]
+
+        for user_last_login in users_last_login:
+            UserFactory(last_login=user_last_login)
+
+    def test_cache_new_instance_data(self):
+        """
+        Verify that cache_instance_data returns data as expected after caching it.
+        """
+        self.create_default_data()
+
+        period_start, period_end = date(2017, 5, 8), date(2017, 5, 15)
+
+        active_students_amount_week = UserProfile.objects.exclude(
+            Q(user__last_login=None) | Q(user__is_active=False)
+        ).filter(user__last_login__gte=period_start, user__last_login__lt=period_end).count()
+
+        cache_timeout = None
+
+        result = cache_instance_data('active_students_amount_week', active_students_amount_week, cache_timeout)
+
+        self.assertEqual(result, 2)
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.cache.get')
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.cache.set')
+    def test_returning_existed_query_result(self, mock_cache_set, mock_cache_get):
+        """
+        Verify that cache_instance_data returns data as expected if it already exists in cache.
+        """
+        mock_cache_get.return_value = 'mock_cached_query_result'
+
+        cache_instance_data('None', None, None)
+
+        self.assertEqual(0, mock_cache_set.call_count)
+
+
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.datetime')
+class TestCacheInstanceDataHelpFunctions(TestCase):
+    """
+    Tests for cache help functions.
+    """
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.date')
+    def test_cache_timeout_week(self, mock_date, mock_datetime):
+        """
+        Verify cache_timeout_week returns correct cache timeout seconds.
+        """
+        mock_datetime.now.return_value = datetime(2017, 7, 9, 23, 55, 0)
+        mock_date.today.return_value = date(2017, 7, 9)
+
+        result = cache_timeout_week()
+
+        self.assertEqual(299, result)
+
+    def test_cache_timeout_month(self, mock_datetime):
+        """
+        Verify cache_timeout_week returns correct cache timeout seconds.
+        """
+        mock_datetime.now.return_value = datetime(2017, 7, 31, 21, 59, 59)
+
+        result = cache_timeout_month()
+
+        self.assertEqual(7200, result)

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py
@@ -5,11 +5,13 @@ Tests for edX global analytics application cache functionality.
 from datetime import date
 
 from mock import patch
-
 from django.test import TestCase
 
-from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import cache_instance_data, get_cache_week_key, get_cache_month_key
-
+from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import (
+    cache_instance_data,
+    get_cache_week_key,
+    get_cache_month_key,
+)
 
 
 @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.cache')
@@ -23,17 +25,19 @@ class TestCacheInstanceData(TestCase):
         Verify that cache_instance_data method return cached query result if it exists in cache.
         """
         mock_cache.get.return_value = True
-        cache_instance_data('name_to_cache', 'query_result')
+        cache_instance_data('name_to_cache', 'query_type', 'activity_period')
 
         mock_cache.set.assert_not_called()
 
-    def test_cache_query_exists(self, mock_cache):
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.get_query_result')
+    def test_cache_query_exists(self, mock_get_query_result, mock_cache):
         """
         Verify that cache_instance_data method set query result if it does not exists in cache.
         """
         mock_cache.get.return_value = None
+        mock_get_query_result.return_value = 'query_result'
 
-        cache_instance_data('name_to_cache', 'query_result')
+        cache_instance_data('name_to_cache', 'active_students_amount', 'activity_period')
 
         mock_cache.set.assert_called_once_with('name_to_cache', 'query_result')
 

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount.py
@@ -10,7 +10,7 @@ from django_countries.fields import Country
 
 from student.tests.factories import UserFactory
 
-from openedx.core.djangoapps.edx_global_analytics.utils.utils import fetch_instance_information
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import fetch_instance_information
 
 
 class TestStudentsAmountPerParticularPeriod(TestCase):

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount.py
@@ -4,15 +4,12 @@ Tests for edX global analytics application functions, that calculate statistics.
 
 import datetime
 
-from mock import patch
-
 from django.test import TestCase
 from django.utils import timezone
 from django_countries.fields import Country
 
 from student.tests.factories import UserFactory
 
-from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import cache_timeout_week
 from openedx.core.djangoapps.edx_global_analytics.utils.utils import fetch_instance_information
 
 
@@ -47,11 +44,8 @@ class TestStudentsAmountPerParticularPeriod(TestCase):
         self.create_default_data()
 
         activity_period = datetime.date(2017, 5, 15), datetime.date(2017, 5, 16)
-        cache_timeout = None
 
-        result = fetch_instance_information(
-            'active_students_amount_day', 'active_students_amount', activity_period, cache_timeout
-        )
+        result = fetch_instance_information('active_students_amount', activity_period, name_to_cache=None)
 
         self.assertEqual(2, result)
 
@@ -69,28 +63,10 @@ class TestStudentsAmountPerParticularPeriod(TestCase):
             profile.save()
 
         activity_period = datetime.date(2017, 5, 15), datetime.date(2017, 5, 16)
-        cache_timeout = None
 
-        result = fetch_instance_information(
-            'students_per_country', 'students_per_country', activity_period, cache_timeout
-        )
+        result = fetch_instance_information('students_per_country', activity_period, name_to_cache=None)
 
         self.assertItemsEqual({u'US': 1, u'CA': 1}, result)
-
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.cache_instance_data')
-    def test_caching_students_with_timeout(self, mock_cache_instance_data):
-        """
-        Verify that cache_instance_data called during fetch instance information method is occurring
-        with not none `cache_timeout`.
-        """
-        activity_period = datetime.date(2017, 5, 15), datetime.date(2017, 5, 16)
-        cache_timeout = cache_timeout_week()
-
-        fetch_instance_information(
-            'students_per_country', 'students_per_country', activity_period, cache_timeout
-        )
-
-        mock_cache_instance_data.assert_called_once()
 
     def test_no_students_with_country(self):
         """
@@ -101,10 +77,7 @@ class TestStudentsAmountPerParticularPeriod(TestCase):
         UserFactory.create(last_login=last_login)
 
         activity_period = datetime.date(2017, 5, 15), datetime.date(2017, 5, 16)
-        cache_timeout = None
 
-        result = fetch_instance_information(
-            'students_per_country', 'students_per_country', activity_period, cache_timeout
-        )
+        result = fetch_instance_information('students_per_country', activity_period, name_to_cache=None)
 
         self.assertEqual({None: 0}, result)

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount_helpers.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount_helpers.py
@@ -8,7 +8,7 @@ from ddt import ddt, data, unpack
 from mock import patch
 from django.test import TestCase
 
-from openedx.core.djangoapps.edx_global_analytics.utils.utils import (
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import (
     get_previous_day_start_and_end_dates,
     get_previous_week_start_and_end_dates,
     get_previous_month_start_and_end_dates,
@@ -16,7 +16,7 @@ from openedx.core.djangoapps.edx_global_analytics.utils.utils import (
 
 
 @ddt
-@patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.date')
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.date')
 class TestStudentsAmountPerParticularPeriodHelpFunctions(TestCase):
     """
     Tests for edX global analytics application functions, that help to calculate statistics.

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_platform_coordinates.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_platform_coordinates.py
@@ -7,14 +7,14 @@ import unittest
 import requests
 from mock import patch, call
 
-from openedx.core.djangoapps.edx_global_analytics.utils.utils import (
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import (
     get_coordinates_by_platform_city_name,
     get_coordinates_by_ip,
     platform_coordinates,
 )
 
 
-@patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.requests.get')
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.requests.get')
 class TestPlatformCoordinates(unittest.TestCase):
     """
     Tests for platform coordinates methods, that gather latitude and longitude.
@@ -110,7 +110,7 @@ class TestPlatformCoordinates(unittest.TestCase):
         )
 
 
-@patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.get_coordinates_by_platform_city_name')
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.get_coordinates_by_platform_city_name')
 class TestPlatformCoordinatesHandler(unittest.TestCase):
     """
     Tests for platform_coordinates method, that handle platform coordinates receiving from independent APIs.
@@ -130,7 +130,7 @@ class TestPlatformCoordinatesHandler(unittest.TestCase):
             (latitude, longitude), result
         )
 
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.get_coordinates_by_ip')
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.get_coordinates_by_ip')
     def test_platform_coordinates_handles_to_freegeoip(
             self, mock_get_coordinates_by_ip, mock_get_coordinates_by_platform_city_name
     ):

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_statistics_bunches.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_statistics_bunches.py
@@ -45,7 +45,7 @@ class TestStatisticsLevelBunches(unittest.TestCase):
         enthusiast_level_statistics_bunch()
 
         mock_fetch_instance_information.assert_called_once_with(
-            'students_per_country', 'students_per_country', get_previous_day_start_and_end_dates(), cache_timeout=None
+            'students_per_country', get_previous_day_start_and_end_dates(), name_to_cache=None
         )
 
     def test_enthusiast_statistics_result(self, mock_fetch_instance_information):
@@ -57,6 +57,4 @@ class TestStatisticsLevelBunches(unittest.TestCase):
 
         result = enthusiast_level_statistics_bunch()
 
-        self.assertEqual(
-            mock_students_per_country, result
-        )
+        self.assertEqual(mock_students_per_country, result)

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_statistics_bunches.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_statistics_bunches.py
@@ -7,7 +7,7 @@ from datetime import date
 
 from mock import patch
 
-from openedx.core.djangoapps.edx_global_analytics.utils.utils import get_previous_day_start_and_end_dates
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import get_previous_day_start_and_end_dates
 from openedx.core.djangoapps.edx_global_analytics.tasks import (
     enthusiast_level_statistics_bunch,
     paranoid_level_statistics_bunch
@@ -32,7 +32,7 @@ class TestStatisticsLevelBunches(unittest.TestCase):
             (5, 5, 5), result
         )
 
-    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utils.get_previous_day_start_and_end_dates')
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.get_previous_day_start_and_end_dates')
     def test_fetching_enthusiast_statistics(
             self, mock_get_previous_day_start_and_end_dates, mock_fetch_instance_information
     ):

--- a/openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py
+++ b/openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py
@@ -5,12 +5,14 @@ Cache functionality.
 from datetime import date, timedelta
 
 from django.core.cache import cache
+from django.db.models import Count
+from django.db.models import Q
+from student.models import UserProfile
 
 
-def cache_instance_data(name_to_cache, query_result):
+def cache_instance_data(name_to_cache, query_type, activity_period):
     """
-    Cache queries, that calculate particular instance data,
-    including long time unchangeable weekly and monthly statistics.
+    Cache queries, that calculate particular instance data with week and month activity period value.
 
     Arguments:
         name_to_cache (str): year-week or year-month accordance as string.
@@ -23,6 +25,7 @@ def cache_instance_data(name_to_cache, query_result):
     if cached_query_result is not None:
         return cached_query_result
 
+    query_result = get_query_result(query_type, activity_period)
     cache.set(name_to_cache, query_result)
 
     return query_result
@@ -49,3 +52,24 @@ def get_cache_month_key():
     year = previous_month.year
 
     return '{0}-{1}-month'.format(year, month_number)
+
+
+def get_query_result(query_type, activity_period):
+    """
+    Return query result per query type.
+    """
+    period_start, period_end = activity_period
+
+    if query_type == 'active_students_amount':
+        return UserProfile.objects.exclude(
+            Q(user__last_login=None) | Q(user__is_active=False)
+        ).filter(user__last_login__gte=period_start, user__last_login__lt=period_end).count()
+
+    if query_type == 'students_per_country':
+        return dict(
+            UserProfile.objects.exclude(
+                Q(user__last_login=None) | Q(user__is_active=False)
+            ).filter(user__last_login__gte=period_start, user__last_login__lt=period_end).values(
+                'country'
+            ).annotate(count=Count('country')).values_list('country', 'count')
+        )

--- a/openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py
+++ b/openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py
@@ -1,0 +1,48 @@
+"""
+Cache functionality.
+"""
+
+from datetime import date, timedelta
+
+from django.core.cache import cache
+
+
+def cache_instance_data(name_to_cache, query_result):
+    """
+    Cache queries, that calculate particular instance data,
+    including long time unchangeable weekly and monthly statistics.
+
+    Arguments:
+        name_to_cache (str): Name of query.
+        query_result (query result): Django-query result.
+        cache_timeout (int/None): Caching for particular seconds amount.
+
+    Returns cached query result.
+    """
+    cached_query_result = cache.get(name_to_cache)
+
+    if cached_query_result is not None:
+        return cached_query_result
+
+    cache.set(name_to_cache, query_result)
+
+    return query_result
+
+
+def get_cache_week_key():
+    """
+    Return year and week number of previous week as unique string key for cache.
+    """
+    year, week_number, _ = (date.today() - timedelta(days=7)).isocalendar()
+    return '%s-%s'.format(year, week_number)
+
+
+def get_cache_month_key():
+    """
+    Return year and month number of previous week as unique string key for cache.
+    """
+    previous_month = (date.today() - timedelta(days=date.today().day))
+    month_number = previous_month.month
+    year = previous_month.year
+
+    return '%s-%s'.format(year, month_number)

--- a/openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py
+++ b/openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py
@@ -13,9 +13,8 @@ def cache_instance_data(name_to_cache, query_result):
     including long time unchangeable weekly and monthly statistics.
 
     Arguments:
-        name_to_cache (str): Name of query.
+        name_to_cache (str): year-week or year-month accordance as string.
         query_result (query result): Django-query result.
-        cache_timeout (int/None): Caching for particular seconds amount.
 
     Returns cached query result.
     """
@@ -31,18 +30,22 @@ def cache_instance_data(name_to_cache, query_result):
 
 def get_cache_week_key():
     """
-    Return year and week number of previous week as unique string key for cache.
+    Return previous week `year` and `week` numbers as unique string key for cache.
     """
-    year, week_number, _ = (date.today() - timedelta(days=7)).isocalendar()
-    return '%s-%s'.format(year, week_number)
+    previous_week = date.today() - timedelta(days=7)
+    year, week_number, _ = previous_week.isocalendar()
+
+    return '{0}-{1}-week'.format(year, week_number)
 
 
 def get_cache_month_key():
     """
-    Return year and month number of previous week as unique string key for cache.
+    Return previous month `year` and `month` numbers as unique string key for cache.
     """
-    previous_month = (date.today() - timedelta(days=date.today().day))
+    current_month_days_count = date.today().day
+    previous_month = (date.today() - timedelta(days=current_month_days_count))
+
     month_number = previous_month.month
     year = previous_month.year
 
-    return '%s-%s'.format(year, month_number)
+    return '{0}-{1}-month'.format(year, month_number)

--- a/openedx/core/djangoapps/edx_global_analytics/utils/token_utils.py
+++ b/openedx/core/djangoapps/edx_global_analytics/utils/token_utils.py
@@ -7,7 +7,7 @@ import httplib
 import requests
 
 from openedx.core.djangoapps.edx_global_analytics.models import AccessTokensStorage
-from openedx.core.djangoapps.edx_global_analytics.utils.utils import request_exception_handler_with_logger
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import request_exception_handler_with_logger
 
 
 def clean_unauthorized_access_token():


### PR DESCRIPTION
`openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py` — new cache implementation based on year-month-week indexes as keys to cache instead of `timeout`.

`openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py`  — tests for cache.