### PR TITLE
Production ready. Implement sending edx platform's statistics to OLGA 

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -120,7 +120,7 @@ CELERYBEAT_SCHEDULE = {
 
     'collect_stats': {
         'task': 'openedx.core.djangoapps.edx_global_analytics.tasks.collect_stats',
-        'schedule': crontab(hour=0, minute=random.randint(1, 59)),
+        'schedule': 15,
     }
 }
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -119,8 +119,8 @@ CELERYBEAT_SCHEDULE = {
     """
 
     'collect_stats': {
-    'task': 'openedx.core.djangoapps.edx_global_analytics.tasks.collect_stats',
-    'schedule': crontab(hour=0, minute=random.randint(1, 59))
+        'task': 'openedx.core.djangoapps.edx_global_analytics.tasks.collect_stats',
+        'schedule': crontab(hour=0, minute=random.randint(1, 59)),
     }
 }
 
@@ -129,6 +129,10 @@ CELERYBEAT_SCHEDULE = {
 
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
+
+# Celery time zone settings for periodic task.
+OLGA_SETTINGS = ENV_TOKENS.get('OPENEDX_LEARNERS_GLOBAL_ANALYTICS')
+CELERY_TIMEZONE = OLGA_SETTINGS.get('CELERY_TIMEZONE') or TIME_ZONE
 
 # STATIC_ROOT specifies the directory where static files are
 # collected

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -120,7 +120,7 @@ CELERYBEAT_SCHEDULE = {
 
     'collect_stats': {
         'task': 'openedx.core.djangoapps.edx_global_analytics.tasks.collect_stats',
-        'schedule': 15,
+        'schedule': crontab(hour=0, minute=random.randint(1, 59)),
     }
 }
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -966,7 +966,15 @@ if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
         )
     )
 
-# include edx global analytics app view.
+# Include edX global analytics application urls.
+EDX_GLOBAL_ANALYTICS_APP_URL = 'edx_global_analytics_app/'
+
 urlpatterns += (
-    url(r'^acceptor_data/', include('openedx.core.djangoapps.edx_global_analytics.urls', namespace='global-analytics')),
+    url(
+        r'^{0}'.format(EDX_GLOBAL_ANALYTICS_APP_URL),
+        include(
+            'openedx.core.djangoapps.edx_global_analytics.urls',
+            namespace='global-analytics'
+        )
+    ),
 )

--- a/openedx/core/djangoapps/edx_global_analytics/admin.py
+++ b/openedx/core/djangoapps/edx_global_analytics/admin.py
@@ -3,13 +3,14 @@ Django admin page for edX global analytics application.
 """
 
 from django.contrib import admin
-from .models import TokenStorage
+
+from openedx.core.djangoapps.edx_global_analytics.models import AccessTokensStorage
 
 
-class TokenStorageAdmin(admin.ModelAdmin):
+class AccessTokensStorageAdmin(admin.ModelAdmin):
     """
-    Admin for token`s storage.
+    Admin for access tokens storage.
     """
-    fields = ['secret_token']
+    fields = ['access_token']
 
-admin.site.register(TokenStorage, TokenStorageAdmin)
+admin.site.register(AccessTokensStorage, AccessTokensStorageAdmin)

--- a/openedx/core/djangoapps/edx_global_analytics/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/edx_global_analytics/migrations/0001_initial.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AccessTokensStorage',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('access_token', models.CharField(max_length=255, null=True)),
+            ],
+        ),
+    ]

--- a/openedx/core/djangoapps/edx_global_analytics/models.py
+++ b/openedx/core/djangoapps/edx_global_analytics/models.py
@@ -5,10 +5,10 @@ Models for the edX global analytics application.
 from django.db import models
 
 
-class TokenStorage(models.Model):
+class AccessTokensStorage(models.Model):
     """
     This model represents relationship`s key with analytics-server.
 
-    `secret_token` is a sequence of characters as special key.
+    `access_token` is a sequence of characters as special key for data sending access.
     """
-    secret_token = models.CharField(max_length=255, null=True)
+    access_token = models.CharField(max_length=255, null=True)

--- a/openedx/core/djangoapps/edx_global_analytics/tasks.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tasks.py
@@ -1,27 +1,25 @@
 """
-This file contains periodic tasks for global_statistics, which will collect data about Open eDX users
+This file contains periodic tasks for edx_global_statistics, which will collect data about Open eDX users
 and send this data to appropriate service for further processing.
 """
 
 import json
 import logging
 
-import requests
 from celery.task import task
-
 from django.conf import settings
 from django.contrib.sites.models import Site
-
 from xmodule.modulestore.django import modulestore
-from .models import TokenStorage
 
-from .utils import (
+from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import get_cache_week_key, get_cache_month_key
+from openedx.core.djangoapps.edx_global_analytics.utils.token_utils import get_acceptor_api_access_token
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import (
     fetch_instance_information,
     get_previous_day_start_and_end_dates,
     get_previous_week_start_and_end_dates,
     get_previous_month_start_and_end_dates,
-    cache_timeout_week,
-    cache_timeout_month
+    platform_coordinates,
+    send_instance_statistics_to_acceptor,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,22 +28,19 @@ logger.setLevel(logging.INFO)
 
 def paranoid_level_statistics_bunch():
     """
-    Gathers particular bunch of instance data called `Paranoid`, that contains active students amount
+    Gather particular bunch of instance data called `Paranoid`, that contains active students amount
     for day, week and month.
     """
     active_students_amount_day = fetch_instance_information(
-        'active_students_amount_day', 'active_students_amount',
-        get_previous_day_start_and_end_dates(), cache_timeout=None
+        'active_students_amount', get_previous_day_start_and_end_dates(), name_to_cache=None
     )
 
     active_students_amount_week = fetch_instance_information(
-        'active_students_amount_week', 'active_students_amount',
-        get_previous_week_start_and_end_dates(), cache_timeout_week()
+        'active_students_amount', get_previous_week_start_and_end_dates(), name_to_cache=get_cache_week_key()
     )
 
     active_students_amount_month = fetch_instance_information(
-        'active_students_amount_month', 'active_students_amount',
-        get_previous_month_start_and_end_dates(), cache_timeout_month()
+        'active_students_amount', get_previous_month_start_and_end_dates(), name_to_cache=get_cache_month_key()
     )
 
     return active_students_amount_day, active_students_amount_week, active_students_amount_month
@@ -53,14 +48,29 @@ def paranoid_level_statistics_bunch():
 
 def enthusiast_level_statistics_bunch():
     """
-    Gathers particular bunch of instance data called `Enthusiast`, that contains students per country amount.
+    Gather particular bunch of instance data called `Enthusiast`, that contains students per country amount.
     """
     students_per_country = fetch_instance_information(
-        'students_per_country', 'students_per_country',
-        get_previous_day_start_and_end_dates(), cache_timeout=None
+        'students_per_country', get_previous_day_start_and_end_dates(), name_to_cache=None,
     )
 
     return students_per_country
+
+
+def get_olga_acceptor_url(olga_settings):
+    """
+    Return OLGA acceptor url that edX application needs to send statistics to.
+    """
+    acceptor_url = olga_settings.get('ACCEPTOR_URL')
+    acceptor_url_develop = olga_settings.get('ACCEPTOR_URL_DEVELOP')
+
+    olga_acceptor_url = acceptor_url or acceptor_url_develop
+
+    if not olga_acceptor_url:
+        logger.info('No OLGA periodic task URL.')
+        return
+
+    return olga_acceptor_url
 
 
 @task
@@ -71,91 +81,55 @@ def collect_stats():
 
     Sending information depends on statistics level in settings, that have an effect on bunch of data size.
     """
-
-    # OLGA settings
     if 'OPENEDX_LEARNERS_GLOBAL_ANALYTICS' not in settings.ENV_TOKENS:
-        return logger.info('No OpenEdX Learners Global Analytics settings in file `lms.env.json`.')
+        logger.info('No OpenEdX Learners Global Analytics settings in file `lms.env.json`.')
+        return
 
     olga_settings = settings.ENV_TOKENS.get('OPENEDX_LEARNERS_GLOBAL_ANALYTICS')
 
-    # Secret token to authorize our platform on remote server.
-    try:
-        token_object = TokenStorage.objects.first()
-        secret_token = token_object.secret_token
-    except AttributeError:
-        secret_token = ""
+    olga_acceptor_url = get_olga_acceptor_url(olga_settings)
 
-    # Current edx-platform URL.
-    platform_url = "https://" + settings.SITE_NAME
+    access_token = get_acceptor_api_access_token(olga_acceptor_url)
 
-    # Predefined in the server settings url to send collected data to.
-    # For production development.
-    if olga_settings.get('OLGA_PERIODIC_TASK_POST_URL'):
-        post_url = olga_settings.get('OLGA_PERIODIC_TASK_POST_URL')
-    # For local development.
-    else:
-        post_url = olga_settings.get('OLGA_PERIODIC_TASK_POST_URL_LOCAL')
+    if not access_token:
+        logger.info('Access token was unsuccessfully authorized. Task will try to register a new token in next turn.')
+        return
 
-    # Posts desired data volume to receiving server.
     # Data volume depends on server settings.
     statistics_level = olga_settings.get("STATISTICS_LEVEL")
 
-    # Paranoid level basic data.
     courses_amount = len(modulestore().get_courses())
 
     (active_students_amount_day,
      active_students_amount_week,
      active_students_amount_month) = paranoid_level_statistics_bunch()
 
+    # Paranoid statistics level basic data.
     data = {
+        'access_token': access_token,
         'active_students_amount_day': active_students_amount_day,
         'active_students_amount_week': active_students_amount_week,
         'active_students_amount_month': active_students_amount_month,
         'courses_amount': courses_amount,
         'statistics_level': 'paranoid',
-        'secret_token': secret_token
     }
 
-    # Enthusiast level (extends Paranoid level)
-    if statistics_level == 1:
-        # Get IP address of the platform and convert it to latitude, longitude.
-        ip_data = requests.get('http://freegeoip.net/json')
-        ip_data_json = json.loads(ip_data.text)
-
-        platform_latitude = olga_settings.get("PLATFORM_LATITUDE")
-        platform_longitude = olga_settings.get("PLATFORM_LONGITUDE")
-
-        if platform_latitude and platform_longitude:
-            latitude, longitude = platform_latitude, platform_longitude
-        else:
-            latitude, longitude = ip_data_json['latitude'], ip_data_json['longitude']
-
-        # Platform name.
+    if statistics_level == 'enthusiast':
+        platform_url = "https://" + settings.SITE_NAME
         platform_name = settings.PLATFORM_NAME or Site.objects.get_current()
+        platform_city_name = olga_settings.get("PLATFORM_CITY_NAME")
 
-        # Get students per country.
+        latitude, longitude = platform_coordinates(platform_city_name)
+
         students_per_country = enthusiast_level_statistics_bunch()
 
-        # Update basic Paranoid`s data
         data.update({
             'latitude': latitude,
             'longitude': longitude,
             'platform_name': platform_name,
             'platform_url': platform_url,
             'statistics_level': 'enthusiast',
-            'students_per_country': json.dumps(students_per_country)
+            'students_per_country': json.dumps(students_per_country),
         })
 
-    try:
-        request = requests.post(post_url, data)
-        logger.info('Connected without error to {0}'.format(request.url))
-
-        if request.status_code == 201:
-            logger.info('Data were successfully transferred to Olga acceptor. Status code is 201.')
-        else:
-            logger.info('Data were not successfully transferred to Olga acceptor. Status code is {0}.'.format(
-                request.status_code
-            ))
-
-    except requests.RequestException as error:
-        logger.exception(error.message)
+    send_instance_statistics_to_acceptor(olga_acceptor_url, data)

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage.py
@@ -1,0 +1,66 @@
+"""
+Tests acceptor API usage by edx global analytics application functions aka utils.
+"""
+
+import httplib
+import unittest
+import uuid
+
+from ddt import ddt, data, unpack
+from mock import patch, call
+
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import send_instance_statistics_to_acceptor
+from openedx.core.djangoapps.edx_global_analytics.utils.token_utils import (
+    access_token_authorization,
+    access_token_registration,
+)
+
+
+@ddt
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.requests.post')
+class TestAcceptorApiUsage(unittest.TestCase):
+    """
+    Test functionality for acceptor API usage.
+    """
+
+    def tests_sending_requests(self, mock_request):
+        """
+        Tests to prove that methods send request to needed corresponding URLs.
+        """
+
+        # Verify that access_token_registration sends request to acceptor API for token registration.
+        access_token_registration('https://mock-url.com')
+
+        # Verify that access_token_authorization sends request to acceptor API for token authorization.
+        mock_access_token = uuid.uuid4().hex
+        access_token_authorization(mock_access_token, 'https://mock-url.com')
+
+        # Verify that send_instance_statistics_to_acceptor sends request to acceptor API for token dispatch statistics.
+        send_instance_statistics_to_acceptor('https://mock-url.com', {'mock_data': 'mock_data', })
+
+        expected_calls = [
+            call('https://mock-url.com/api/token/registration/'),
+            call('https://mock-url.com/api/token/authorization/', data={'access_token': mock_access_token}),
+            call('https://mock-url.com/api/installation/statistics/', {'mock_data': 'mock_data'}),
+        ]
+
+        self.assertEqual(mock_request.call_args_list, expected_calls)
+
+
+    @data(
+        [httplib.CREATED, 'Data were successfully transferred to OLGA acceptor. Status code is {0}.'],
+        [httplib.BAD_REQUEST, 'Data were not successfully transferred to OLGA acceptor. Status code is {0}.']
+    )
+    @unpack
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.logging.Logger.info')
+    def test_sent_statistics(self, status_code, log_message, mock_logging, mock_request):
+        """
+        Verify that send_instance_statistics_to_acceptor successfully dispatches statistics to acceptor API.
+        """
+        mock_request.return_value.status_code = status_code
+
+        send_instance_statistics_to_acceptor('https://mock-url.com', {'mock_data': 'mock_data', })
+
+        mock_logging.assert_called_with(
+            log_message.format(mock_request.return_value.status_code)
+        )

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage_helpers.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_acceptor_api_usage_helpers.py
@@ -1,0 +1,75 @@
+"""
+Tests for OLGA acceptor api usage by edX global analytics application tasks and helper functions.
+"""
+
+import logging
+import unittest
+import uuid
+
+import requests
+from mock import patch
+
+from openedx.core.djangoapps.edx_global_analytics.utils.token_utils import get_access_token
+
+logger = logging.getLogger(__name__)
+
+
+class TestAcceptorApiUsageHelpFunctions(unittest.TestCase):
+    """
+    Tests for OLGA acceptor api usage by edX global analytics application tasks and helper functions.
+    """
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.request_exception_handler_with_logger')
+    def test_decorator_if_no_exception(self, mock_request_exception_handler_with_logger):
+        """
+        Test request_exception_handler_with_logger return wrapped function, if Request Exception does not exist.
+        """
+        def mock_decorated_function(mock):
+            """
+            Mock decorated function.
+            """
+            return mock
+
+        mock_request_exception_handler_with_logger.return_value = mock_decorated_function('mock')
+
+        result = mock_request_exception_handler_with_logger()
+
+        self.assertEqual(mock_decorated_function('mock'), result)
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.logging.Logger.exception')
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.request_exception_handler_with_logger')
+    def test_decorator_if_exception(self, mock_request_exception_handler_with_logger, mock_logging_exception):
+        """
+        Test request_exception_handler_with_logger log exception if whatever happened with request.
+        """
+        mock_request_exception_handler_with_logger.return_value.side_effect = requests.RequestException()
+        mock_logging_exception.exception.assert_called_once()
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.models.AccessTokensStorage.objects.first')
+    def test_returning_token_if_token_exists(self, mock_access_tokens_storage_model_objects_first_method):
+        """
+        Verify that get_access_token gets access token from access tokens storage if it exists.
+        """
+        mock_access_token = uuid.uuid4().hex
+
+        class MockAccessTokensStorageModelFirstObject(object):
+            """
+            Mock class for AccessTokensStorage model first object.
+            """
+            access_token = mock_access_token
+
+        mock_access_tokens_storage_model_objects_first_method.return_value = MockAccessTokensStorageModelFirstObject()
+
+        result = get_access_token()
+
+        self.assertEqual(mock_access_token, result)
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.models.AccessTokensStorage.objects.first')
+    def test_returning_empty_line_if_no_token(self, mock_access_tokens_storage_model_objects_first_method):
+        """
+        Verify that get_access_token return None if access token does not exist in access tokens storage.
+        """
+        mock_access_tokens_storage_model_objects_first_method.return_value = None
+        result = get_access_token()
+
+        self.assertEqual(None, result)

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_cache_instance_data.py
@@ -1,0 +1,74 @@
+"""
+Tests for edX global analytics application cache functionality.
+"""
+
+from datetime import date
+
+from ddt import ddt, data, unpack
+from mock import patch
+from django.test import TestCase
+
+from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import (
+    cache_instance_data,
+    get_cache_week_key,
+    get_cache_month_key,
+)
+
+
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.cache')
+class TestCacheInstanceData(TestCase):
+    """
+    Tests for cache instance data method.
+    """
+
+    def test_cache_query_does_not_exists(self, mock_cache):
+        """
+        Verify that cache_instance_data method return cached query result if it exists in cache.
+        """
+        mock_cache.get.return_value = True
+        cache_instance_data('name_to_cache', 'query_type', 'activity_period')
+
+        mock_cache.set.assert_not_called()
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.get_query_result')
+    def test_cache_query_exists(self, mock_get_query_result, mock_cache):
+        """
+        Verify that cache_instance_data method set query result if it does not exists in cache.
+        """
+        mock_cache.get.return_value = None
+        mock_get_query_result.return_value = 'query_result'
+
+        cache_instance_data('name_to_cache', 'query_type', 'activity_period')
+
+        mock_cache.set.assert_called_once_with('name_to_cache', 'query_result')
+
+
+@ddt
+class TestCacheInstanceDataHelpFunctions(TestCase):
+    """
+    Tests for cache help functions.
+    """
+
+    @data(
+        [date(2017, 1, 9), get_cache_week_key, '2017-1-week'],
+        [date(2017, 4, 9), get_cache_month_key, '2017-3-month']
+    )
+    @unpack
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.cache_utils.date')
+    def test_cache_keys(self, fake_date, get_cache_key, expected_result, mock_date):
+        """
+        Verify that `get cache key` methods return correct cache keys.
+
+        `get_cache_week_key`:
+            - 9th January is a monday, it is second week from year's start.
+            - returns previous week `year` and `week` numbers.
+
+        `get_cache_month_key`:
+            - 4th month is an April.
+            - get_cache_month_key returns previous month `year` and `month` numbers.
+        """
+        mock_date.today.return_value = fake_date
+
+        result = get_cache_key()
+
+        self.assertEqual(expected_result, result)

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount.py
@@ -1,0 +1,83 @@
+"""
+Tests for edX global analytics application functions, that calculate statistics.
+"""
+
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+from django_countries.fields import Country
+
+from student.tests.factories import UserFactory
+
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import fetch_instance_information
+
+
+class TestStudentsAmountPerParticularPeriod(TestCase):
+    """
+    Cover all methods, that have a deal with statistics calculation.
+    """
+
+    @staticmethod
+    def create_default_data():
+        """
+        Default integration database data for active students amount functionality.
+        """
+        users_last_login = [
+            timezone.make_aware(datetime.datetime(2017, 5, 14, 23, 59, 59), timezone.get_default_timezone()),
+            timezone.make_aware(datetime.datetime(2017, 5, 15, 0, 0, 0), timezone.get_default_timezone()),
+            timezone.make_aware(datetime.datetime(2017, 5, 15, 23, 59, 59), timezone.get_default_timezone()),
+            timezone.make_aware(datetime.datetime(2017, 5, 16, 0, 0, 0), timezone.get_default_timezone()),
+            timezone.make_aware(datetime.datetime(2017, 5, 16, 0, 0, 1), timezone.get_default_timezone())
+        ]
+
+        for user_last_login in users_last_login:
+            UserFactory(last_login=user_last_login)
+
+    def test_fetch_active_students(self):
+        """
+        Verify that fetch_instance_information returns data as expected in particular period and accurate datetime.
+
+        We have no reason to test week and month periods for active students amount,
+        all queries are the same, we just go test only day period.
+        """
+        self.create_default_data()
+
+        activity_period = datetime.date(2017, 5, 15), datetime.date(2017, 5, 16)
+
+        result = fetch_instance_information('active_students_amount', activity_period, name_to_cache=None)
+
+        self.assertEqual(2, result)
+
+    def test_fetch_students_per_country(self):
+        """
+        Verify that students_per_country returns data as expected in particular period and accurate datetime.
+        """
+        last_login = timezone.make_aware(datetime.datetime(2017, 5, 15, 14, 23, 23), timezone.get_default_timezone())
+        countries = [u'US', u'CA']
+
+        for country in countries:
+            user = UserFactory.create(last_login=last_login)
+            profile = user.profile
+            profile.country = Country(country)
+            profile.save()
+
+        activity_period = datetime.date(2017, 5, 15), datetime.date(2017, 5, 16)
+
+        result = fetch_instance_information('students_per_country', activity_period, name_to_cache=None)
+
+        self.assertItemsEqual({u'US': 1, u'CA': 1}, result)
+
+    def test_no_students_with_country(self):
+        """
+        Verify that students_per_country returns data as expected if no students with country.
+        """
+        last_login = timezone.make_aware(datetime.datetime(2017, 5, 15, 14, 23, 23), timezone.get_default_timezone())
+
+        UserFactory.create(last_login=last_login)
+
+        activity_period = datetime.date(2017, 5, 15), datetime.date(2017, 5, 16)
+
+        result = fetch_instance_information('students_per_country', activity_period, name_to_cache=None)
+
+        self.assertEqual({None: 0}, result)

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount_helpers.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_instance_students_amount_helpers.py
@@ -1,0 +1,43 @@
+"""
+Tests for edX global analytics application functions, that help to calculate statistics.
+"""
+
+from datetime import date
+
+from ddt import ddt, data, unpack
+from mock import patch
+from django.test import TestCase
+
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import (
+    get_previous_day_start_and_end_dates,
+    get_previous_week_start_and_end_dates,
+    get_previous_month_start_and_end_dates,
+)
+
+
+@ddt
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.date')
+class TestStudentsAmountPerParticularPeriodHelpFunctions(TestCase):
+    """
+    Tests for edX global analytics application functions, that help to calculate statistics.
+    """
+
+    @data(
+        [get_previous_day_start_and_end_dates, (date(2017, 6, 13), date(2017, 6, 14))],
+        [get_previous_week_start_and_end_dates, (date(2017, 6, 5), date(2017, 6, 12))],
+        [get_previous_month_start_and_end_dates, (date(2017, 5, 1), date(2017, 6, 1))],
+    )
+    @unpack
+    def test_calendar_periods(self, calendar_period, expected_result, mock_date):
+        """
+        Verify that methods, that gather calendar period return expected day start and end dates.
+
+        Test to prove:
+            - that get_previous_day_start_and_end_dates returns expected previous day start and end dates.
+            - that test_get_previous_week_start_and_end_dates returns expected previous week start and end dates.
+            - that test_get_previous_month_start_and_end_dates returns expected previous month start and end dates.
+        """
+
+        mock_date.today.return_value = date(2017, 6, 14)
+
+        self.assertEqual(expected_result, calendar_period())

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_platform_coordinates.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_platform_coordinates.py
@@ -1,0 +1,150 @@
+"""
+Tests for edx global analytics application tasks and helper functions.
+"""
+
+import unittest
+
+import requests
+from mock import patch, call
+
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import (
+    get_coordinates_by_platform_city_name,
+    get_coordinates_by_ip,
+    platform_coordinates,
+)
+
+
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.requests.get')
+class TestPlatformCoordinates(unittest.TestCase):
+    """
+    Tests for platform coordinates methods, that gather latitude and longitude.
+    """
+
+    def tests_sending_requests(self, mock_request):
+        """
+        Tests to prove that methods send request to needed corresponding URLs.
+        """
+
+        # Verify that get_coordinates_by_platform_city_name sends request to Google API with address as parameter.
+        get_coordinates_by_platform_city_name('Kiev')
+
+        # Verify that get_coordinates_by_ip sends request to FreeGeoIP API.
+        get_coordinates_by_ip()
+
+        expected_calls = [
+            call('https://maps.googleapis.com/maps/api/geocode/json', params={'address': 'Kiev'}),
+            call('https://freegeoip.net/json'),
+        ]
+
+        self.assertEqual(mock_request.call_args_list, expected_calls)
+
+    def test_platform_city_name_result(self, mock_request):
+        """
+        Verify that get_coordinates_by_platform_city_name returns city latitude and longitude as expected.
+        """
+        mock_request.return_value.json.return_value = {
+            'results': [{
+                'geometry': {
+                    'location': {
+                        'lat': 50.4501,
+                        'lng': 30.5234
+                    }
+                }
+            }]
+        }
+
+        latitude, longitude = get_coordinates_by_platform_city_name('Kiev')
+        self.assertEqual(
+            (50.4501, 30.5234), (latitude, longitude)
+        )
+
+    def test_platform_city_name_if_no_city_name(
+            self, mock_request
+    ):
+        """
+        Verify that get_coordinates_by_platform_city_name returns city latitude and longitude
+        although city name in settings is empty.
+        """
+        mock_request.return_value.json.return_value = {
+            'results': []
+        }
+
+        result_without_city_name = get_coordinates_by_platform_city_name('')
+        self.assertEqual(None, result_without_city_name)
+
+    def test_platform_city_name_if_wrong_city_name(
+            self, mock_request
+    ):
+        """
+        Verify that get_coordinates_by_platform_city_name returns None if platform city name in settings is wrong.
+        """
+        mock_request.return_value.json.return_value = {
+            'results': []
+        }
+
+        result_without_city_name = get_coordinates_by_platform_city_name('Lmnasasfabqwrqrn')
+        self.assertEqual(None, result_without_city_name)
+
+    def test_get_coordinates_by_ip_result(self, mock_request):
+        """
+        Verify that get_coordinates_by_ip returns city latitude and longitude as expected.
+        """
+        mock_request.return_value.json.return_value = {
+            'latitude': 50.4333,
+            'longitude': 30.5167
+        }
+
+        latitude, longitude = get_coordinates_by_ip()
+        self.assertEqual(
+            (50.4333, 30.5167), (latitude, longitude)
+        )
+
+    def test_get_coordinates_by_ip_if_exception(self, mock_request):
+        """
+        Verify that get_coordinates_by_ip returns empty latitude and longitude after request exception.
+        """
+        mock_request.side_effect = requests.RequestException()
+        latitude, longitude = get_coordinates_by_ip()
+        self.assertEqual(
+            ('', ''), (latitude, longitude)
+        )
+
+
+@patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.get_coordinates_by_platform_city_name')
+class TestPlatformCoordinatesHandler(unittest.TestCase):
+    """
+    Tests for platform_coordinates method, that handle platform coordinates receiving from independent APIs.
+    """
+
+    def test_platform_coordinates_handles_to_google_api(self, mock_get_coordinates_by_platform_city_name):
+        """
+        Verify that platform_coordinates returns platform coordinates from Google API.
+        """
+        latitude, longitude = 50.4333, 30.5167
+
+        mock_get_coordinates_by_platform_city_name.return_value = 50.4333, 30.5167
+
+        result = platform_coordinates('Kiev')
+
+        self.assertEqual(
+            (latitude, longitude), result
+        )
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.get_coordinates_by_ip')
+    def test_platform_coordinates_handles_to_freegeoip(
+            self, mock_get_coordinates_by_ip, mock_get_coordinates_by_platform_city_name
+    ):
+        """
+        Verify that platform_coordinates returns platform coordinates from FreeGeoIP API
+        if Google API does not return it.
+        """
+        latitude, longitude = 50.4333, 30.5167
+
+        mock_get_coordinates_by_platform_city_name.return_value = None
+        mock_get_coordinates_by_ip.return_value = latitude, longitude
+
+        result = platform_coordinates('Kiev')
+
+        self.assertEqual(
+            (latitude, longitude), result
+        )

--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_statistics_bunches.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_statistics_bunches.py
@@ -1,0 +1,60 @@
+"""
+Tests for statistics level bunches, that provides particular edX installation statistics.
+"""
+
+import unittest
+from datetime import date
+
+from mock import patch
+
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import get_previous_day_start_and_end_dates
+from openedx.core.djangoapps.edx_global_analytics.tasks import (
+    enthusiast_level_statistics_bunch,
+    paranoid_level_statistics_bunch
+)
+
+
+@patch('openedx.core.djangoapps.edx_global_analytics.tasks.fetch_instance_information')
+class TestStatisticsLevelBunches(unittest.TestCase):
+    """
+    Tests for statistics level bunches, that provides particular edX installation statistics.
+    """
+
+    def test_paranoid_statistics_result(self, mock_fetch_instance_information):
+        """
+        Verify that paranoid_level_statistics_bunch_method returns active students amount per day, week and month.
+        """
+        mock_fetch_instance_information.return_value = 5
+
+        result = paranoid_level_statistics_bunch()
+
+        self.assertEqual(
+            (5, 5, 5), result
+        )
+
+    @patch('openedx.core.djangoapps.edx_global_analytics.utils.utilities.get_previous_day_start_and_end_dates')
+    def test_fetching_enthusiast_statistics(
+            self, mock_get_previous_day_start_and_end_dates, mock_fetch_instance_information
+    ):
+        """
+        Verify that enthusiast_level_statistics_bunch_method calls needed fetch instance information method for
+        students per country.
+        """
+        mock_get_previous_day_start_and_end_dates.return_value = date(2017, 7, 3), date(2017, 7, 4)
+
+        enthusiast_level_statistics_bunch()
+
+        mock_fetch_instance_information.assert_called_once_with(
+            'students_per_country', get_previous_day_start_and_end_dates(), name_to_cache=None
+        )
+
+    def test_enthusiast_statistics_result(self, mock_fetch_instance_information):
+        """
+        Verify that enthusiast_level_statistics_bunch_method return students per country statistics.
+        """
+        mock_students_per_country = {'US': 5, 'CA': 10}
+        mock_fetch_instance_information.return_value = mock_students_per_country
+
+        result = enthusiast_level_statistics_bunch()
+
+        self.assertEqual(mock_students_per_country, result)

--- a/openedx/core/djangoapps/edx_global_analytics/urls.py
+++ b/openedx/core/djangoapps/edx_global_analytics/urls.py
@@ -1,10 +1,3 @@
 """
 URLs for the edX global analytics application.
 """
-
-from django.conf.urls import url
-from . import views
-
-urlpatterns = [
-    url(r'^$', views.ReceiveTokenView.as_view(), name='receive-token'),
-]

--- a/openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py
+++ b/openedx/core/djangoapps/edx_global_analytics/utils/cache_utils.py
@@ -1,0 +1,76 @@
+"""
+Cache functionality.
+"""
+
+from datetime import date, timedelta
+
+from django.core.cache import cache
+from django.db.models import Count
+from django.db.models import Q
+
+from student.models import UserProfile
+
+
+def cache_instance_data(name_to_cache, query_type, activity_period):
+    """
+    Cache queries, that calculate particular instance data with week and month activity period value.
+
+    Arguments:
+        name_to_cache (str): year-week or year-month accordance as string.
+        query_result (query result): Django-query result.
+
+    Returns cached query result.
+    """
+    cached_query_result = cache.get(name_to_cache)
+
+    if cached_query_result is not None:
+        return cached_query_result
+
+    query_result = get_query_result(query_type, activity_period)
+    cache.set(name_to_cache, query_result)
+
+    return query_result
+
+
+def get_query_result(query_type, activity_period):
+    """
+    Return query result per query type.
+    """
+    period_start, period_end = activity_period
+
+    if query_type == 'active_students_amount':
+        return UserProfile.objects.exclude(
+            Q(user__last_login=None) | Q(user__is_active=False)
+        ).filter(user__last_login__gte=period_start, user__last_login__lt=period_end).count()
+
+    if query_type == 'students_per_country':
+        return dict(
+            UserProfile.objects.exclude(
+                Q(user__last_login=None) | Q(user__is_active=False)
+            ).filter(user__last_login__gte=period_start, user__last_login__lt=period_end).values(
+                'country'
+            ).annotate(count=Count('country')).values_list('country', 'count')
+        )
+
+
+def get_cache_week_key():
+    """
+    Return previous week `year` and `week` numbers as unique string key for cache.
+    """
+    previous_week = date.today() - timedelta(days=7)
+    year, week_number, _ = previous_week.isocalendar()
+
+    return '{0}-{1}-week'.format(year, week_number)
+
+
+def get_cache_month_key():
+    """
+    Return previous month `year` and `month` numbers as unique string key for cache.
+    """
+    current_month_days_count = date.today().day
+    previous_month = (date.today() - timedelta(days=current_month_days_count))
+
+    month_number = previous_month.month
+    year = previous_month.year
+
+    return '{0}-{1}-month'.format(year, month_number)

--- a/openedx/core/djangoapps/edx_global_analytics/utils/token_utils.py
+++ b/openedx/core/djangoapps/edx_global_analytics/utils/token_utils.py
@@ -1,0 +1,83 @@
+"""
+Providers for access token`s authentication flow.
+"""
+
+import httplib
+
+import requests
+
+from openedx.core.djangoapps.edx_global_analytics.models import AccessTokensStorage
+from openedx.core.djangoapps.edx_global_analytics.utils.utilities import request_exception_handler_with_logger
+
+
+def clean_unauthorized_access_token():
+    """
+    Delete first and sole access token in storage.
+
+    If instance unsuccessfully authorized, statistics dispatch flow needs to registry access token again.
+    """
+    AccessTokensStorage.objects.first().delete()
+
+
+def get_access_token():
+    """
+    Return single access token for authorization.
+
+    This application works only with single OLGA acceptor for now.
+    So access token is needed to make relationship between `edx_global_analytics` and `OLGA`.
+    Reference: https://github.com/raccoongang/acceptor
+    """
+    token_object = AccessTokensStorage.objects.first()
+
+    if token_object:
+        return token_object.access_token
+
+
+@request_exception_handler_with_logger
+def access_token_registration(olga_acceptor_url):
+    """
+    Request access token from OLGA and store it.
+    """
+    token_registration_request = requests.post(olga_acceptor_url + '/api/token/registration/')
+    access_token = token_registration_request.json()['access_token']
+
+    AccessTokensStorage.objects.create(access_token=access_token)
+
+    return access_token
+
+
+@request_exception_handler_with_logger
+def access_token_authorization(access_token, olga_acceptor_url):
+    """
+    Verify that installation is allowed to send statistics to OLGA acceptor.
+
+    If edX platform won't be authorized, method clear existing access token.
+    Task will try to register a new token in next turn.
+    """
+    token_authorization_request = requests.post(
+        olga_acceptor_url + '/api/token/authorization/', data={'access_token': access_token, }
+    )
+
+    if token_authorization_request.status_code == httplib.UNAUTHORIZED:
+        clean_unauthorized_access_token()
+        return
+
+    return access_token
+
+
+def get_acceptor_api_access_token(olga_acceptor_url):
+    """
+    Provide access token`s authentication flow for getting access token and return it.
+
+    If access token does not exist, method goes to register it.
+    After successful registration edX platform authorizes itself via access token.
+
+    If instance successfully authorized, method returns access token.
+    If not it cleans token in storage and goes ahead to repeat flow.
+    """
+    access_token = get_access_token()
+
+    if not access_token:
+        access_token = access_token_registration(olga_acceptor_url)
+
+    return access_token_authorization(access_token, olga_acceptor_url)

--- a/openedx/core/djangoapps/edx_global_analytics/utils/utilities.py
+++ b/openedx/core/djangoapps/edx_global_analytics/utils/utilities.py
@@ -1,0 +1,152 @@
+"""
+Helpers for the edX global analytics application.
+"""
+
+import calendar
+import httplib
+import logging
+from datetime import date, timedelta
+
+import requests
+
+from openedx.core.djangoapps.edx_global_analytics.utils.cache_utils import cache_instance_data, get_query_result
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def fetch_instance_information(query_type, activity_period, name_to_cache=None):
+    """
+    Calculate instance information corresponding for particular period as like as previous calendar day and
+    statistics type as like as students per country after cached if needed.
+    """
+    if name_to_cache is not None:
+        return cache_instance_data(name_to_cache, query_type, activity_period)
+
+    return get_query_result(query_type, activity_period)
+
+
+def get_previous_day_start_and_end_dates():
+    """
+    Get accurate start and end dates, that create segment between them equal to a full last calendar day.
+
+    Returns:
+        start_of_day (date): Previous day`s start. Example for 2017-05-15 is 2017-05-15.
+        end_of_day (date): Previous day`s end, it`s a next day (tomorrow) toward day`s start,
+                           that doesn't count in segment. Example for 2017-05-15 is 2017-05-16.
+    """
+    end_of_day = date.today()
+    start_of_day = end_of_day - timedelta(days=1)
+
+    return start_of_day, end_of_day
+
+
+def get_previous_week_start_and_end_dates():
+    """
+    Get accurate start and end dates, that create segment between them equal to a full last calendar week.
+
+    Returns:
+        start_of_week (date): Calendar week`s start day. Example for 2017-05-17 is 2017-05-08.
+        end_of_week (date): Calendar week`s end day, it`s the first day of next week, that doesn't count in segment.
+                             Example for 2017-05-17 is 2017-05-15.
+    """
+    days_after_week_started = date.today().weekday() + 7
+
+    start_of_week = date.today() - timedelta(days=days_after_week_started)
+    end_of_week = start_of_week + timedelta(days=7)
+
+    return start_of_week, end_of_week
+
+
+def get_previous_month_start_and_end_dates():
+    """
+    Get accurate start and end dates, that create segment between them equal to a full last calendar month.
+
+    Returns:
+        start_of_month (date): Calendar month`s start day. Example for may is 2017-04-01.
+        end_of_month (date): Calendar month`s end day, it`s the first day of next month, that doesn't count in segment.
+                             Example for may is 2017-05-01.
+    """
+    previous_month_date = date.today().replace(day=1) - timedelta(days=1)
+
+    start_of_month = previous_month_date.replace(day=1)
+    end_of_month = previous_month_date.replace(
+        day=calendar.monthrange(previous_month_date.year, previous_month_date.month)[1]
+    ) + timedelta(days=1)
+
+    return start_of_month, end_of_month
+
+
+def get_coordinates_by_ip():
+    """
+    Gather coordinates by server IP address with FreeGeoIP service.
+    """
+    try:
+        ip_data = requests.get('https://freegeoip.net/json')
+        latitude, longitude = ip_data.json()['latitude'], ip_data.json()['longitude']
+        return latitude, longitude
+
+    except requests.RequestException as error:
+        logger.exception(error.message)
+        return '', ''
+
+
+def get_coordinates_by_platform_city_name(city_name):
+    """
+    Gather coordinates by platform city name with Google API.
+    """
+    google_api_request = requests.get(
+        'https://maps.googleapis.com/maps/api/geocode/json', params={'address': city_name}
+    )
+
+    coordinates_result = google_api_request.json()['results']
+
+    if coordinates_result:
+        location = coordinates_result[0]['geometry']['location']
+        return location['lat'], location['lng']
+
+
+def platform_coordinates(city_name):
+    """
+    Get platform city latitude and longitude.
+
+    If `city_platform_located_in` (name of city) exists in OLGA setting (lms.env.json) as manual parameter
+    Google API helps to get city latitude and longitude. Else FreeGeoIP gathers latitude and longitude by IP address.
+
+    All correct city names are available from Wikipedia -
+    https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+
+    Module `pytz` also has list of cities with `pytz.all_timezones`.
+    """
+    return get_coordinates_by_platform_city_name(city_name) or get_coordinates_by_ip()
+
+
+def request_exception_handler_with_logger(function):
+    """
+    Request Exception decorator. Logs error message if it exists.
+    """
+    def request_exception_wrapper(*args, **kwargs):
+        """
+        Decorator wrapper.
+        """
+        try:
+            return function(*args, **kwargs)
+        except requests.RequestException as error:
+            logger.exception(error.message)
+            return
+
+    return request_exception_wrapper
+
+
+@request_exception_handler_with_logger
+def send_instance_statistics_to_acceptor(olga_acceptor_url, data):
+    """
+    Dispatch installation statistics OLGA acceptor.
+    """
+    request = requests.post(olga_acceptor_url + '/api/installation/statistics/', data)
+    status_code = request.status_code
+
+    if status_code == httplib.CREATED:
+        logger.info('Data were successfully transferred to OLGA acceptor. Status code is {0}.'.format(status_code))
+    else:
+        logger.info('Data were not successfully transferred to OLGA acceptor. Status code is {0}.'.format(status_code))

--- a/openedx/core/djangoapps/edx_global_analytics/views.py
+++ b/openedx/core/djangoapps/edx_global_analytics/views.py
@@ -1,38 +1,3 @@
 """
 Views for the edX global analytics application for working with analytics-server and other inside features.
 """
-
-from django.http import Http404, HttpResponse
-from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import View
-
-from .models import TokenStorage
-
-
-class ReceiveTokenView(View):
-    """
-    Receives a secret token from the remote server and save it to DB.
-    This will allow edx-platform to exchange data with a remote server.
-    """
-    @method_decorator(csrf_exempt)
-    def dispatch(self, *args, **kwargs):
-        return super(ReceiveTokenView, self).dispatch(*args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
-        """
-        Receive generated token from the remote server and save it to DB.
-
-        `secret_token` is uuid.UUID object converted to string.
-
-        Return http status code based on success of the token's save operation.
-        """
-
-        try:
-            received_data = request.POST
-            secret_token = str(received_data.get('secret_token'))
-            TokenStorage.objects.update_or_create(
-                pk=1, defaults={"secret_token": secret_token})
-            return HttpResponse(status=201)
-        except ValueError:
-            raise Http404()


### PR DESCRIPTION
## Overall info

Periodic task sends stats daily:
- Active students amount per calendar day, week and month.
- Courses and students amount per country.
- Some instance information: name, url, location.

Following statistics level available:
- Enthusiast send more data.
- Paranoid send less data.
- Also you can send no data.

Features:
- Cache for large queries.

## Settings

Add settings below to `lms.env.json`.

```
"OPENEDX_LEARNERS_GLOBAL_ANALYTICS": {
    "CELERY_TIMEZONE": "Europe/Kiev",
    "ACCEPTOR_URL": "https://olga-demo.raccoongang.com",
    "ACCEPTOR_URL_DEVELOP": "",
    "PLATFORM_CITY_NAME": "Kiev",
    "STATISTICS_LEVEL": "enthusiast"
    },
```

I added `acceptor url` oriented on testing stage environments.

## Celery

On `devstack` to run `celery` task I do:

```
./manage.py lms celery worker -B --settings=devstack_with_worker
```

## Review

All parts of this code are reviewed. [Proof](https://github.com/raccoongang/edx-platform/pulls?q=is%3Aclosed+author%3Admytrostriletskyi).  