### PR TITLE
Fixed the page of about and fixed the page of reset password

### DIFF
--- a/lms/static/sass/multicourse/_account.scss
+++ b/lms/static/sass/multicourse/_account.scss
@@ -658,7 +658,8 @@
 .view-passwordreset {
 
   .header-global .nav-courseware .btn-login {
-    display: none;
+    display: inline-block;
+    vertical-align: middle;
   }
 
   .introduction {

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -10,12 +10,12 @@
     box-shadow: 0 1px 80px 0 rgba(0,0,0, 0.5);
     border-bottom: 1px solid $border-color-3;
     box-shadow: inset 0 1px 5px 0 $shadow-l1;
-    height: 280px;
-    margin-top: $header_image_margin;
-    padding-top: 150px;
     overflow: hidden;
     position: relative;
     width: 100%;
+    height: auto;
+    margin-top: 0;
+    padding: 20px 0px;
 
     .intro-inner-wrapper {
       background: $course-header-bg;


### PR DESCRIPTION
1. The page of course about fixed. There was a fixed height and when the block has much a lot of text the block will have an incorrect view and crushed. I changed a fixed height to a height: auto.
first image
![about-page-after](https://user-images.githubusercontent.com/12746043/29078925-709137c0-7c64-11e7-9a90-9f5bf6e406fc.png)
second image
![about-page-before](https://user-images.githubusercontent.com/12746043/29078931-73a2e83c-7c64-11e7-9c4b-b2d85cc7d35d.png)


2. If a user resets a password and targets to a link from an email he will not have a button of the sign in. I changed styles for this button from display: none to display: inline-block
first image
![reset-password-after](https://user-images.githubusercontent.com/12746043/29078945-7dafe564-7c64-11e7-9512-37a3f7a14ddd.png)
second image
![reset-password-before](https://user-images.githubusercontent.com/12746043/29078950-8051a6cc-7c64-11e7-9860-fb2ffbe44168.png)
