### PR TITLE
fixed npm dependency to disable update to major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "backbone-validation": "~0.11.5",
     "coffee-script": "1.6.1",
     "edx-pattern-library": "0.18.0",
-    "edx-ui-toolkit": "1.5.1",
+    "edx-ui-toolkit": "1.5.2",
     "jquery": "~2.2.0",
     "jquery-migrate": "^1.4.1",
     "jquery.scrollto": "~2.1.2",


### PR DESCRIPTION
_npm_ library _sinon_ has been updated to 3.3.0 version brokes compatibility with open edX platform. Fix updates _edx-ui-toolkit_ library to 1.5.2 version which have hard _sinon_ requirement.
https://github.com/edx/edx-ui-toolkit/blob/v1.5.2/package.json#L29