### PR TITLE
changed markey version to fix paver i18n_ modules

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -18,7 +18,7 @@ cssselect==0.9.1
 dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.5.1
-markey==0.7  # From django-babel-underscore
+markey==0.8  # From django-babel-underscore
 django-celery==3.1.16
 django-config-models==0.1.3
 django-countries==4.0


### PR DESCRIPTION
any project with new language configuration has problems with `paver i18n_*` modules