### PR TITLE
Fix django-wiki requirements.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@
 
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.10#egg=django-wiki==0.0.10
+-e git+https://github.com/edx/django-wiki.git@v0.0.16#egg=django-wiki
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
Fix edx-platform requirements

issue:

```
/edx/app/edxapp/venvs/edxapp/bin/pip install -r /edx/app/edxapp/edx-platform/requirements/edx/github.txt

...
Collecting Django>=1.4 (from django-wiki==0.0.10)
  Using cached Django-2.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-yJeICp/Django/setup.py", line 32, in <module>
        version = __import__('django').get_version()
      File "django/__init__.py", line 1, in <module>
        from django.utils.version import get_version
      File "django/utils/version.py", line 61, in <module>
        @functools.lru_cache()
    AttributeError: 'module' object has no attribute 'lru_cache'
```

edx-platform PR: https://github.com/edx/edx-platform/pull/16764

@sidorovdmitry
@a-kryachko 
@Marx86 
@imatviian  
@hetmantsev 
please review