### PR TITLE
fixed XSS vulnerable URI parameter "next=" in site login and register…

### DIFF
--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 import third_party_auth
 from third_party_auth import provider, pipeline
+from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 
 <%block name="pagetitle">${_("Log into your {platform_name} Account").format(platform_name=platform_name)}</%block>
@@ -65,7 +66,7 @@ from third_party_auth import provider, pipeline
 
       $('#login-form').on('ajax:success', function(event, json, xhr) {
         if(json.success) {
-          var nextUrl = "${login_redirect_url}";
+          var nextUrl = "${login_redirect_url | n, js_escaped_string}";
           if (json.redirect_url) {
             nextUrl = json.redirect_url; // Most likely third party auth completion. This trumps 'nextUrl' above.
           }

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -10,6 +10,7 @@ from student.models import UserProfile
 from datetime import date
 import third_party_auth
 from third_party_auth import pipeline, provider
+from openedx.core.djangolib.js_utils import js_escaped_string
 import calendar
 %>
 
@@ -53,7 +54,7 @@ import calendar
       });
 
       $('#register-form').on('ajax:success', function(event, json, xhr) {
-        var nextUrl = "${login_redirect_url}";
+        var nextUrl = "${login_redirect_url | n, js_escaped_string}";
         if (json.redirect_url) {
           nextUrl = json.redirect_url; // Most likely third party auth completion. This trumps 'nextUrl' above.
         }


### PR DESCRIPTION
Force to transform login_redirect_url on site login and register pages by js_escaped_string function to disable to exploit XSS injections thought ```next=``` GET parameter.  OpenEdx documentation [Preventing XSS](https://github.com/edx/edx-documentation/blob/master/en_us/developers/source/conventions/preventing_xss.rst). Problem description and QA report is available at RaccoonGang's Trello board.