### PR TITLE
Fix nltk requiremts (switch to forked edx repo).

### DIFF
--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -10,4 +10,7 @@ setup(
         "scipy==0.14.0",
         "nltk==2.0.6",
     ],
+    dependency_links=[
+        "git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6",
+    ],
 )


### PR DESCRIPTION
issue:
No matching distribution found for nltk==2.0.6 (from chem==0.1.1->-r ./requirements/edx/local.txt (line 5))

edx PR: https://github.com/edx/edx-platform/pull/16753/files

@sidorovdmitry 
@a-kryachko 
@imatviian 
@hetmantsev 
@Marx86 
please review