### PR TITLE
Add test for fix username missing field

### DIFF
--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -165,7 +165,7 @@ class AdminUserPageTest(TestCase):
         super(AdminUserPageTest, self).setUp()
         self.admin = UserAdmin(User, AdminSite())
 
-    def test_username_is_readonly_for_empty_user(self):
+    def test_username_is_writable_for_user_creation(self):
         """
         Ensures that the username is not readonly, when admin creates new user.
         """

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -165,7 +165,14 @@ class AdminUserPageTest(TestCase):
         super(AdminUserPageTest, self).setUp()
         self.admin = UserAdmin(User, AdminSite())
 
-    def test_username_is_readonly(self):
+    def test_username_is_readonly_for_empty_user(self):
+        """
+        Ensures that the username is not readonly, when admin creates new user.
+        """
+        request = Mock()
+        self.assertNotIn('username', self.admin.get_readonly_fields(request))
+
+    def test_username_is_readonly_for_user(self):
         """
         Ensures that the username is readonly to skip Django validation in the `auth_user_change` view.
 
@@ -175,4 +182,5 @@ class AdminUserPageTest(TestCase):
         stores the username in a different database.
         """
         request = Mock()
-        self.assertIn('username', self.admin.get_readonly_fields(request))
+        user = Mock()
+        self.assertIn('username', self.admin.get_readonly_fields(request, user))

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -174,7 +174,9 @@ class AdminUserPageTest(TestCase):
 
     def test_username_is_readonly_for_user(self):
         """
-        Ensures that the username is readonly to skip Django validation in the `auth_user_change` view.
+        Ensures that the username field is readonly, when admin open user which already exists.
+        
+        This hook used for skip Django validation in the `auth_user_change` view.
 
         Changing the username is still possible using the database or from the model directly.
 


### PR DESCRIPTION
Add test in the case when admin creates a user from the dashboard and need permission to set the username. 