### PR TITLE
add Jenkinsfile and fix .coveragerc for CI tests for ginkgo-rg

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -45,7 +45,6 @@ output = reports/coverage.xml
 [paths]
 jenkins_source =
     /home/jenkins/workspace/$JOB_NAME
-    /home/jenkins/workspace/$SUBSET_JOB
 
 devstack_source =
     /edx/app/edxapp/edx-platform

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,93 @@
+#!groovy
+
+def startTests(suite, shard) {
+        return {
+                node("${suite}-${shard}-worker") {
+                        wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 1, 'defaultBg': 2]) {
+                                cleanWs()
+                                checkout scm
+                                try {
+                                        withEnv(["TEST_SUITE=${suite}", "SHARD=${shard}"]) {
+                                                sh './scripts/all-tests.sh'
+                                        }
+                                } finally {
+                                        archiveArtifacts 'reports/**, test_root/log/**'
+                                        stash includes: 'reports/**, test_root/log/**', name: "artifacts-${suite}-${shard}"
+                                        junit 'reports/**/*.xml'
+                                        deleteDir()
+                                }
+                        }
+                }
+        }
+}
+
+
+def coverageTest() {
+        node('coverage-report-worker') {
+                wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 1, 'defaultBg': 2]) {
+                        cleanWs()
+                        checkout scm
+                        try {
+                                unstash 'artifacts-lms-unit-1'
+                                unstash 'artifacts-lms-unit-2'
+                                unstash 'artifacts-lms-unit-3'
+                                unstash 'artifacts-lms-unit-4'
+                                unstash 'artifacts-cms-unit-all'
+                                withCredentials([string(credentialsId: 'rg-codecov-edx-platform-token', variable: 'CODE_COV_TOKEN')]) {
+                                        sh "git rev-parse --short HEAD^1 > .git/ci-branch-id"
+                                        sh "git rev-parse --short HEAD^2 > .git/target-branch-id"
+                                        def CI_BRANCH = readFile('.git/ci-branch-id')
+                                        def TARGET_BRANCH = readFile('.git/target-branch-id')
+                                        sh './scripts/jenkins-report.sh'
+                                }
+                        } finally {
+                                archiveArtifacts 'reports/**, test_root/log/**'
+                                cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'reports/coverage.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+                                deleteDir()
+                        }
+                }
+        }
+}
+
+def getSuites() {
+        return [
+                [name: 'lms-unit', 'shards': [
+                1,
+                2,
+                3,
+                4,
+                ]],
+                [name: 'cms-unit', 'shards': ['all']],
+        ]
+}
+
+def buildParallelSteps() {
+        def parallelSteps = [:]
+
+        for (def suite in getSuites()) {
+                def name = suite['name']
+
+                for (def shard in suite['shards']) {
+                        parallelSteps["${name}_${shard}"] = startTests(name, shard)
+                }
+        }
+
+        return parallelSteps
+}
+
+stage('Prepare') {
+        echo 'Starting the build...'
+}
+
+stage('Unit tests') {
+        parallel buildParallelSteps()
+}
+
+stage('Coverage') {
+        coverageTest()
+}
+
+stage('Done') {
+        echo 'Done! :)'
+}
+


### PR DESCRIPTION
.coveragerc
/home/jenkins/workspace/$SUBSET_JOB - this parameter was used with old jenkins plugin called buildflow.
This plugin was deprecated and parameter is not needed anymore, because it causes an error with coverage tests (duplicating folder name).
"When combining data with the combine command, two file paths will be combined if they start with paths from the same list."
https://coverage.readthedocs.io/en/coverage-4.2/config.html#paths

Jenkinsfile
This file needed because we are using jenkinspipeline in our ci tests. When file is exists - jenkins start pipeline according to this. It's contains 2 stages (Testing, Reporting) + 2 (Prepairing, Done).
Here is the link to tests. Jenkinsfile worked correctly.
https://jenkins.raccoongang.com/view/Autotests/job/raccoongang/job/edx-platform/view/change-requests/job/PR-138/9/

Diff coverage is 80% on methods, lines and 70% on conditionals.