### PR TITLE
Fix activation_email SUPPORT_SITE_LINK text.

### DIFF
--- a/lms/templates/emails/activation_email.txt
+++ b/lms/templates/emails/activation_email.txt
@@ -1,4 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
+<% from django.conf import settings %>
 ${_("You're almost there! Use the link to activate your account to access engaging, high-quality "
 "{platform_name} courses. Note that you will not be able to log back into your account until "
 "you have activated it.").format(platform_name=platform_name)}
@@ -13,9 +14,11 @@ ${_("Enjoy learning with {platform_name}.").format(platform_name=platform_name)}
 
 ${_("The {platform_name} Team").format(platform_name=platform_name)}
 
+% if settings.SUPPORT_SITE_LINK != '':
 ${_("If you need help, please use our web form at {support_url} or email {support_email}.").format(
   support_url=support_url, support_email=support_email
 )}
+% endif
 
 ${_("This email message was automatically sent by {lms_url} because someone attempted to create an "
 "account on {platform_name} using this email address.").format(


### PR DESCRIPTION
QA team gives a task to fix missing link to support page in activation email.
Example: https://www.screencast.com/t/2yFYzimn1Sx
To not develop and design a "support page" and corresponding server variables this patch is proposed.
Patch applied on every new project and pass QA checks.
@sidorovdmitry @dgamanenko please review.