### PR TITLE
add slack-notifications, timeouts in Jenkinsfile for CI tests (ginkgo-rg) 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,19 +2,23 @@
 
 def startTests(suite, shard) {
         return {
-                node("${suite}-${shard}-worker") {
-                        wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 1, 'defaultBg': 2]) {
-                                cleanWs()
-                                checkout scm
-                                try {
-                                        withEnv(["TEST_SUITE=${suite}", "SHARD=${shard}"]) {
-                                                sh './scripts/all-tests.sh'
+                timeout(35) {
+                        node("${suite}-${shard}-worker") {
+                                wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 1, 'defaultBg': 2]) {
+                                        cleanWs()
+                                        checkout scm
+                                        try {
+                                                withEnv(["TEST_SUITE=${suite}", "SHARD=${shard}"]) {
+                                                        sh './scripts/all-tests.sh'
+                                                }
+                                        } catch (err) {
+                                                slackSend channel: "${env.CHANNEL_NAME}", color: 'danger', message: "Test ${suite}-${shard} failed in ${env.JOB_NAME}. Please check build info. (<${env.BUILD_URL}|Open>)", teamDomain: 'raccoongang', tokenCredentialId: 'slack-secret-token'
+                                        } finally {
+                                                archiveArtifacts 'reports/**, test_root/log/**'
+                                                stash includes: 'reports/**, test_root/log/**', name: "artifacts-${suite}-${shard}"
+                                                junit 'reports/**/*.xml'
+                                                deleteDir()
                                         }
-                                } finally {
-                                        archiveArtifacts 'reports/**, test_root/log/**'
-                                        stash includes: 'reports/**, test_root/log/**', name: "artifacts-${suite}-${shard}"
-                                        junit 'reports/**/*.xml'
-                                        deleteDir()
                                 }
                         }
                 }
@@ -75,8 +79,13 @@ def buildParallelSteps() {
         return parallelSteps
 }
 
+environment {
+        CHANNEL_NAME = "ci-open-edx"
+}
+
 stage('Prepare') {
         echo 'Starting the build...'
+        slackSend channel: "${env.CHANNEL_NAME}", color: 'good', message: "CI Tests started! ${env.JOB_NAME} (<${env.BUILD_URL}|Open>)", teamDomain: 'raccoongang', tokenCredentialId: 'slack-secret-token'
 }
 
 stage('Unit tests') {
@@ -89,5 +98,5 @@ stage('Coverage') {
 
 stage('Done') {
         echo 'Done! :)'
+	slackSend channel: "${env.CHANNEL_NAME}", color: 'good', message: "CI Tests finished! ${env.JOB_NAME} (<${env.BUILD_URL}|Open>)", teamDomain: 'raccoongang', tokenCredentialId: 'slack-secret-token'
 }
-


### PR DESCRIPTION
https://trello.com/c/kEPHdMiE/2253-general-add-slack-alerts-for-ci

Notifications are sending in script-channel.

I've added timeout, because job stuck everytime, when tests were finished with segmentation fault error.
(timeout 35min). after 35 minutes pipeline will be killed.