### PR TITLE
Added manage.py cms import-library functionality.

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/import-library.py
+++ b/cms/djangoapps/contentstore/management/commands/import-library.py
@@ -1,0 +1,49 @@
+"""
+Script for importing library content from XML format
+"""
+from optparse import make_option
+
+from django.core.management.base import BaseCommand, CommandError
+
+from django_comment_common.utils import are_permissions_roles_seeded, seed_permissions_roles
+from xmodule.contentstore.django import contentstore
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.xml_importer import import_library_from_xml
+
+
+class Command(BaseCommand):
+    """
+    Import the specified library data directory into the default ModuleStore
+    """
+    help = 'Import the specified library data directory into the default ModuleStore'
+
+    option_list = BaseCommand.option_list + (
+        make_option('--nostatic',
+                    action='store_true',
+                    help='Skip import of static content'),
+    )
+
+    def handle(self, *args, **options):
+        "Execute the command"
+        if len(args) == 0:
+            raise CommandError("import requires at least one argument: <data directory> [--nostatic] [<library dir>...]")
+
+        data_dir = args[0]
+        do_import_static = not options.get('nostatic', False)
+        if len(args) > 1:
+            source_dirs = args[1:]
+        else:
+            source_dirs = None
+        self.stdout.write("Importing.  Data_dir={data}, source_dirs={courses}\n".format(
+            data=data_dir,
+            courses=source_dirs,
+        ))
+        mstore = modulestore()
+
+        course_items = import_library_from_xml(
+            mstore, ModuleStoreEnum.UserID.mgmt_command, data_dir, source_dirs, load_error_modules=False,
+            static_content_store=contentstore(), verbose=True,
+            do_import_static=do_import_static,
+            create_if_not_present=True,
+        )

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -592,21 +592,24 @@ class LibraryImportManager(ImportManager):
         if self.target_id is not None:
             dest_id = self.target_id
         else:
-            dest_id = LibraryLocator(self.target_id.org, self.target_id.library)
+            dest_id = LibraryLocator(courselike_key.org, courselike_key.library)
 
         existing_lib = self.store.get_library(dest_id, ignore_case=True)
 
         runtime = None
 
         if existing_lib:
+            log.info("Importing content into existing library: %s", str(existing_lib))
             dest_id = existing_lib.location.library_key
             runtime = existing_lib.runtime
+        else:
+            log.info("Creating new library: %s", str(courselike_key))
 
         if self.create_if_not_present and not existing_lib:
             try:
                 library = self.store.create_library(
-                    org=self.target_id.org,
-                    library=self.target_id.library,
+                    org=dest_id.org,
+                    library=dest_id.library,
                     user_id=self.user_id,
                     fields={"display_name": ""},
                 )


### PR DESCRIPTION
Add ability to import course libraries automatically with scripts. (needed for mc courses).

cherry-pick from f94048213e49d1326519930755bb45d018a3faeb.

Tested on few mc projects.

Using: 
`sudo -u www-data /edx/bin/python.edxapp /edx/bin/manage.edxapp cms --settings=aws import-library $LIBRARY_PATH`