### PR TITLE
Fix activation_email when SUPPORT_SITE_LINK variable is not defined in LMS environment.

### DIFF
--- a/lms/templates/emails/activation_email.txt
+++ b/lms/templates/emails/activation_email.txt
@@ -1,4 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
+<% from django.conf import settings %>
 ${_("You're almost there! Use the link to activate your account to access engaging, high-quality "
 "{platform_name} courses. Note that you will not be able to log back into your account until "
 "you have activated it.").format(platform_name=platform_name)}
@@ -13,10 +14,12 @@ ${_("Enjoy learning with {platform_name}.").format(platform_name=platform_name)}
 
 ${_("The {platform_name} Team").format(platform_name=platform_name)}
 
+% if settings.SUPPORT_SITE_LINK != '':
 ${_("If you need help, please use our web form at {support_url} or email {support_email}.").format(
   support_url=support_url, support_email=support_email
 )}
 
+% endif
 ${_("This email message was automatically sent by {lms_url} because someone attempted to create an "
 "account on {platform_name} using this email address.").format(
   lms_url=lms_url, platform_name=platform_name


### PR DESCRIPTION
Then variable is not set (by default) part of activation e-mail looks like

```
If you need help, please use our web form at {} or email email@lms.com.
```

The reason for cutting this part:
- default OpenEdx LMS templates has support page with limited access;
- text modification breaks translations.