### PR TITLE
Fix footer and certificate copyright date. (ficus-rg)

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -49,7 +49,7 @@ import lms.envs.common
 # Although this module itself may not use these imported variables, other dependent modules may.
 from lms.envs.common import (
     USE_TZ, TECH_SUPPORT_EMAIL, PLATFORM_NAME, BUGS_EMAIL, DOC_STORE_CONFIG, DATA_DIR, ALL_LANGUAGES, WIKI_ENABLED,
-    update_module_store_settings, ASSET_IGNORE_REGEX, COPYRIGHT_YEAR,
+    update_module_store_settings, ASSET_IGNORE_REGEX,
     PARENTAL_CONSENT_AGE_LIMIT, COMPREHENSIVE_THEME_DIRS, REGISTRATION_EMAIL_PATTERNS_ALLOWED,
     # The following PROFILE_IMAGE_* settings are included as they are
     # indirectly accessed through the email opt-in API, which is

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -1,6 +1,9 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from datetime import datetime
+from django.conf import settings
+import pytz
 %>
 
 <div class="wrapper-footer wrapper">
@@ -8,7 +11,7 @@ from django.core.urlresolvers import reverse
 
     <div class="footer-content-primary">
       <div class="colophon">
-        <p>&copy; ${settings.COPYRIGHT_YEAR} <a data-rel="edx.org" href="${settings.LMS_ROOT_URL}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
+        <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a data-rel="edx.org" href="${settings.LMS_ROOT_URL}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
       </div>
 
       % if is_any_marketing_link_set(['TOS', 'PRIVACY']):

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -3,6 +3,7 @@
 Certificate HTML webview.
 """
 from datetime import datetime
+import pytz
 from uuid import uuid4
 import logging
 import urllib
@@ -154,7 +155,7 @@ def _update_context_with_basic_info(context, course_id, platform_name, configura
     # Translators:  'All rights reserved' is a legal term used in copyrighting to protect published content
     reserved = _("All rights reserved")
     context['copyright_text'] = u'&copy; {year} {platform_name}. {reserved}.'.format(
-        year=settings.COPYRIGHT_YEAR,
+        year=datetime.now(pytz.timezone(settings.TIME_ZONE)).year,
         platform_name=platform_name,
         reserved=reserved
     )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -48,8 +48,6 @@ from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 # The display name of the platform to be used in templates/emails/etc.
 PLATFORM_NAME = "Your Platform Name Here"
 CC_MERCHANT_NAME = PLATFORM_NAME
-# Shows up in the platform footer, eg "(c) COPYRIGHT_YEAR"
-COPYRIGHT_YEAR = "2017"
 
 PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
 PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"

--- a/themes/red-theme/lms/templates/footer.html
+++ b/themes/red-theme/lms/templates/footer.html
@@ -3,6 +3,9 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from django.conf import settings
+from datetime import datetime
+import pytz
 %>
 
 <div class="wrapper wrapper-footer">
@@ -53,7 +56,7 @@ from django.utils.translation import ugettext as _
         </p>
       </div>
 
-      <p class="copyright">&copy; ${settings.COPYRIGHT_YEAR} ${static.get_platform_name()}.</p>
+      <p class="copyright">&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} ${static.get_platform_name()}.</p>
 
       ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
       <p class="copyright">


### PR DESCRIPTION
Add ability to set copyright year dynamically in lms footer and certificate.

Tested on stage fix-date server.
https://www.screencast.com/t/Ebs2W7PH

Cherry-pick from 7813a8e419b88a1dfa3745ab38393843df93cef9 but removed non-ficus footer_language_selector_is_enabled import.
