### PR TITLE
Enable codecov/project report.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,4 +11,7 @@ coverage:
       default:
         target: 95%
         threshold: 1%
-    project: false
+    project:
+      default:
+        target: 80%
+        threshold: 1%


### PR DESCRIPTION
It gives us overall coverage report in github commit status. (80% minimum and 1% treshhold)