### PR TITLE
fix redirect with enroll without login

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -471,6 +471,12 @@ def signin_user(request):
 @ensure_csrf_cookie
 def register_user(request, extra_context=None):
     """Deprecated. To be replaced by :class:`student_account.views.login_and_registration_form`."""
+    if settings.ENABLE_REDIRECT_REGISTER:
+        params = [(param, request.GET[param]) for param in request.GET]
+        if params:
+            return HttpResponseRedirect("{}?{}".format(settings.REGISTER_REDIRECT_URL, urllib.urlencode(params)))
+        else:
+            return HttpResponseRedirect(settings.REGISTER_REDIRECT_URL)
     # Determine the URL to redirect to following login:
     redirect_to = get_next_url_for_login_page(request)
     if request.user.is_authenticated():
@@ -514,12 +520,7 @@ def register_user(request, extra_context=None):
             context.update(overrides)
 
     # if 'ENABLE_REDIRECT_REGISTER' is True redirect to the 'REGISTER_REDIRECT_URL'
-    if settings.ENABLE_REDIRECT_REGISTER:
-        params = [(param, request.GET[param]) for param in request.GET]
-        if params:
-            return HttpResponseRedirect("{}?{}".format(settings.REGISTER_REDIRECT_URL, urllib.urlencode(params)))
-        else:
-            return HttpResponseRedirect(settings.REGISTER_REDIRECT_URL)
+
 
     return render_to_response('register.html', context)
 

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -69,6 +69,13 @@ def login_and_registration_form(request, initial_mode="login"):
         initial_mode (string): Either "login" or "register".
 
     """
+    # if 'ENABLE_REDIRECT_REGISTER' is True redirect to the 'REGISTER_REDIRECT_URL'
+    if settings.ENABLE_REDIRECT_REGISTER and initial_mode == "register":
+        params = [(param, request.GET[param]) for param in request.GET]
+        if params:
+            return HttpResponseRedirect("{}?{}".format(settings.REGISTER_REDIRECT_URL, urllib.urlencode(params)))
+        else:
+            return HttpResponseRedirect(settings.REGISTER_REDIRECT_URL)
     # Determine the URL to redirect to following login/registration/third_party_auth
     redirect_to = get_next_url_for_login_page(request)
     # If we're already logged in, redirect to the dashboard
@@ -93,13 +100,7 @@ def login_and_registration_form(request, initial_mode="login"):
 
     set_enterprise_branding_filter_param(request=request, provider_id=third_party_auth_hint)
 
-    #if 'ENABLE_REDIRECT_REGISTER' is True redirect to the 'REGISTER_REDIRECT_URL'
-    if settings.ENABLE_REDIRECT_REGISTER and initial_mode == "register":
-        params = [(param, request.GET[param]) for param in request.GET]
-        if params:
-            return HttpResponseRedirect("{}?{}".format(settings.REGISTER_REDIRECT_URL, urllib.urlencode(params)))
-        else:
-            return HttpResponseRedirect(settings.REGISTER_REDIRECT_URL)
+
 
     # If this is a themed site, revert to the old login/registration pages.
     # We need to do this for now to support existing themes.


### PR DESCRIPTION
Add a redirect to the external page (setting 'REGISTER_REDIRECT_URL') when setting 'ENABLE_REDIRECT_REGISTER' is True and  go to the registration page or enroll for the course without a login

Link to the Task: https://youtrack.raccoongang.com/issue/NRG-34
