### PR TITLE
Added manage.py cms import-library functionality

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/import-library.py
+++ b/cms/djangoapps/contentstore/management/commands/import-library.py
@@ -1,0 +1,63 @@
+"""
+Script for importing library content from XML format
+"""
+import os
+
+from optparse import make_option
+from django.core.management.base import BaseCommand, CommandError
+from django_comment_common.utils import are_permissions_roles_seeded, seed_permissions_roles
+
+from xmodule.contentstore.django import contentstore
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.xml_importer import import_library_from_xml
+
+class Command(BaseCommand):
+    """
+    Import the specified library data directory into the default ModuleStore
+    """
+    help  = """
+    Import the specified library(s) data directory into the default ModuleStore
+
+    Usage: cms import-library <data_directory> [--nostatic] <library_dir> [<library_dir>...]
+    data_directory - usually /edx/var/edxapp/data
+    library_dir - unpacked archive, obtained via `CMS - Library - Export` interface
+    directory and its content must be readable by www-data user
+    """
+
+    option_list = BaseCommand.option_list + (
+        make_option('--nostatic',
+                    action='store_true',
+                    help='Skip import of static content'),
+    )
+ 
+    def handle(self, *args, **options):
+        """
+        Execute the command
+        """
+        do_import_static = not options.get('nostatic', False)
+        if len(args) < 2:
+            raise CommandError("ERROR: import-library requires at least two arguments: <data_directory> [--nostatic] <library_dir> [<library_dir>...]")
+ 
+        data_dir = args[0]
+        if len(args) > 1:
+            source_dirs = args[1:]
+        else:
+            raise CommandError("ERROR: import-library requires at least one library_dir as argument")
+
+        self.stdout.write("Importing.  Data_dir={data}, source_dirs={courses}\n".format(
+            data=data_dir,
+            courses=source_dirs,
+        ))
+        
+        course_items = import_library_from_xml(
+            modulestore(), ModuleStoreEnum.UserID.mgmt_command, data_dir, source_dirs, load_error_modules=False,
+            static_content_store=contentstore(), verbose=True,
+            do_import_static=do_import_static,
+            create_if_not_present=True,
+        )
+
+        if course_items:
+            self.stdout.write("Successfully imported {} libraries.\n".format(len(course_items)))
+        else:
+            raise CommandError("ERROR: Imported libraries count is zero! Check log for errors.\n")

--- a/cms/djangoapps/contentstore/management/commands/tests/test_import_library.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_import_library.py
@@ -1,0 +1,69 @@
+"""
+Unittests for importing a library via management command
+"""
+
+import ddt
+import os
+from path import Path as path
+import shutil
+import tempfile
+
+from django.core.management import CommandError, call_command
+
+from opaque_keys.edx.locator import LibraryLocator
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+@ddt.ddt
+class TestImportLibrary(ModuleStoreTestCase):
+    """
+    Unit tests for importing a library from command line
+    """
+
+    org = u'TestOrgX'
+    lib_code = u'LC101'
+    display_name = u'Testing Library Import'
+
+    def create_library_xml(self, content_dir):
+        directory = tempfile.mkdtemp(dir=content_dir)
+        os.makedirs(os.path.join(directory, "library"))
+        with open(os.path.join(directory, "library.xml"), "w+") as f:
+            f.write('<library xblock-family="xblock.v1" display_name="{display_name}" org="{org}" '
+                    'library="{lib_code}"/>'.format(display_name=self.display_name, org=self.org, lib_code=self.lib_code))
+
+        return directory
+
+    def setUp(self):
+        """
+        Build library XML for importing
+        """
+        super(TestImportLibrary, self).setUp()
+        self.content_dir = path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.content_dir)
+        self.library_key = LibraryLocator(self.org, self.lib_code)
+        self.library_dir = self.create_library_xml(self.content_dir)
+
+    def test_library_import(self):
+        """
+        Try to import library
+        """
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
+            call_command('import-library', self.content_dir, self.library_dir)
+            self.library_from_store = modulestore().get_library(self.library_key)
+
+        """
+        Compare library_key of imported library with self-generated
+        """
+        self.assertEqual(unicode(self.library_from_store.location.library_key), unicode(self.library_key))
+        """ 
+        Compare display_name of imported library with original
+        """
+        self.assertEqual(unicode(self.library_from_store), u"Library: " + unicode(self.display_name))
+
+    @ddt.data(u'/tmp/xxx/yyy/zzz', u'')
+    def test_library_import_invalid_dirs(self, invalid_source_dir):
+        errstring = "Imported libraries count is zero"
+        with self.assertRaisesRegexp(CommandError, errstring):
+            call_command('import-library', self.content_dir, invalid_source_dir)
+

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -592,21 +592,22 @@ class LibraryImportManager(ImportManager):
         if self.target_id is not None:
             dest_id = self.target_id
         else:
-            dest_id = LibraryLocator(self.target_id.org, self.target_id.library)
+            dest_id = LibraryLocator(courselike_key.org, courselike_key.library)
 
         existing_lib = self.store.get_library(dest_id, ignore_case=True)
 
         runtime = None
 
         if existing_lib:
+            log.info("Importing content into existing library: %s", str(existing_lib))
             dest_id = existing_lib.location.library_key
             runtime = existing_lib.runtime
 
         if self.create_if_not_present and not existing_lib:
             try:
                 library = self.store.create_library(
-                    org=self.target_id.org,
-                    library=self.target_id.library,
+                    org=dest_id.org,
+                    library=dest_id.library,
                     user_id=self.user_id,
                     fields={"display_name": ""},
                 )


### PR DESCRIPTION
Transfer manage.py cms import-library feature from main branch ficus-rg to client.

cherry-picked ee20ab570df6cc857ab5e2cebe73fce761260f1c because stage branch have some differences with prod. 