### PR TITLE
Fix pdf xblock and add image-explorer.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -92,7 +92,8 @@ git+https://github.com/edx/edx-proctoring.git@0.18.1#egg=edx-proctoring==0.18.1
 # Third Party XBlocks
 git+https://github.com/open-craft/xblock-poll@v1.2.7#egg=xblock-poll==1.2.7
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.18#egg=xblock-drag-and-drop-v2==2.0.18
-git+https://github.com/MarCnu/pdfXBlock@8c14efb6938d1d2102330e1d3837e9d11cb60fc8#egg=pdf_xblock
+git+https://github.com/raccoongang/xblock-pdf.git@v1.0.0#egg=xblock-pdf
+git+https://github.com/edx-solutions/xblock-image-explorer@v0.9.0#egg=xblock-image-explorer
 
 #SSO Client for Drupal.
 -e git+https://github.com/raccoongang/edx-oauth-client.git@asu-drupal#egg=edx_oauth_client


### PR DESCRIPTION
Removed deprecated pdf-xblock (not working on ginkgo-release).
I've forked xblock from ioni.sx and edited tranlations. (its fork from deprecated :)

Also i've add image-explorer xblock which neede to use customers course.

Here is xblock list from that course:
"word_cloud", 
"done", 
 "library_content", 
"pdf", 
"google-document", 
"poll", 
"survey", 
"image-explorer", 
"google-calendar", 
"drag-and-drop-v2", 
"lti_consumer"