### PR TITLE
disable api if not have ENABLE_APPSEMPLER_API property

### DIFF
--- a/lms/djangoapps/appsembler_api/utils.py
+++ b/lms/djangoapps/appsembler_api/utils.py
@@ -11,6 +11,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from student.forms import PasswordResetFormNoActive
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 from rest_framework import permissions
+from django.http import Http404
 
 def auto_generate_username(email):
     """
@@ -59,7 +60,10 @@ class ApiKeyHeaderPermissionInToken(ApiKeyHeaderPermission, permissions.IsAuthen
                present in the request and matches the setting.
                """
         api_key = getattr(settings, "EDX_APP_SEMBLER_API_KEY", None)
+        is_enable_api = configuration_helpers.get_value("ENABLE_APPSEMPLER_API", None)
+        if not is_enable_api:
+            raise Http404
         return (
                 (settings.DEBUG and api_key is None) or
-                (api_key is not None and request.META.get("HTTP_X_APP_SEMBLER_API_KEY") == api_key)
+                (is_enable_api is not None and api_key is not None and request.META.get("HTTP_X_APP_SEMBLER_API_KEY") == api_key)
         )


### PR DESCRIPTION
**Description:** Fix problem with emails. Add new settings to 
'admin/site_configuration' to check enable/disable Api for site&
**Youtrack:** https://youtrack.raccoongang.com/issue/NRG-42#tab=Comments

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** 
in 'admin/site_configuration' add next:
{
....
  "email_from_address":"sustainability@nrg.com",
  "ENABLE_APPSEMPLER_API":true
...
}

**Testing instructions:**

1) Api work in microsite  and mail send from `email_from_address`.
2) Api doesn't work in main site.


