### PR TITLE
Fix/base install theme fix

### DIFF
--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -140,7 +140,6 @@ from openedx.core.djangolib.markup import HTML, Text
                                 </table>
                             </li>
                         </ul>
-                    </div>
                 </div>
 
                 <input type="submit" id="calculator_button" value="=" aria-label="${_('Calculate')}">


### PR DESCRIPTION
**Description:** Fix for broken theme

**Youtrack:** https://youtrack.raccoongang.com/issue/UCADEMY-43

**Testing instructions:**

1. Open CMS - Course - Advanced settings
2. Set value of 'Show Calculator' to 'True'
3. Expect: LMS theme footer is static (not floating in background while page is scrolling)
4. If 3 happened instead - check failed.

**Reviewers:**
- [ ] @raccoongang/devops 
