### PR TITLE
Firebrand main (index) page customization

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -134,7 +134,7 @@ class CourseMetadata(object):
                 'editor_type': ''
             }
 
-            if field.name in ['course_category', 'course_format', 'index_visible']:
+            if field.name in ['course_category', 'index_visible']:
                 result[field.name].update({
                     'editor_type': 'select'
                 })

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -134,7 +134,7 @@ class CourseMetadata(object):
                 'editor_type': ''
             }
 
-            if field.name in ['course_category']:
+            if field.name in ['course_category', 'course_format', 'index_visible']:
                 result[field.name].update({
                     'editor_type': 'select'
                 })

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -289,7 +289,7 @@ class CourseMode(models.Model):
         """
         now = datetime.now(pytz.UTC)
 
-        found_course_modes = cls.objects.filter(course_id=course_id)
+        found_course_modes = cls.objects.filter(course_id=course_id).order_by('id')
 
         # Filter out expired course modes if include_expired is not set
         if not include_expired:

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -868,15 +868,11 @@ class CourseFields(object):
         ]
     )
 
-    course_format = String(
-        display_name=_("Format"),
-        help=_('Displays whether the course has "Online" or "Offline" format.'),
-        default="online",
-        scope=Scope.settings,
-        values=[
-            {"display_name": _("Online"), "value": "online"},
-            {"display_name": _("Offline"), "value": "offline"},
-        ]
+    course_vendor = String(
+        display_name=_("Vendor"),
+        help=_('Displays whether the course has vendor.'),
+        default="Microsoft",
+        scope=Scope.settings
     )
 
     index_visible = Boolean(

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -868,6 +868,24 @@ class CourseFields(object):
         ]
     )
 
+    course_format = String(
+        display_name=_("Format"),
+        help=_('Displays whether the course has "Online" or "Offline" format.'),
+        default="online",
+        scope=Scope.settings,
+        values=[
+            {"display_name": _("Online"), "value": "online"},
+            {"display_name": _("Offline"), "value": "offline"},
+        ]
+    )
+
+    index_visible = Boolean(
+        display_name=_("Index page visibility"),
+        help=_('Does this course appear on the index page?'),
+        default=False,
+        scope=Scope.settings,
+    )
+
 
 class CourseModule(CourseFields, SequenceModule):  # pylint: disable=abstract-method
     """

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -228,4 +228,6 @@ class AdvancedSettingsPage(CoursePage):
             'create_zendesk_tickets',
             'ccx_connector',
             'enable_ccx',
+            'course_format',
+            'index_visible',
         ]

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -228,6 +228,6 @@ class AdvancedSettingsPage(CoursePage):
             'create_zendesk_tickets',
             'ccx_connector',
             'enable_ccx',
-            'course_format',
+            'course_vendor',
             'index_visible',
         ]

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -3,8 +3,10 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from openedx.core.djangoapps.models.course_details import CourseDetails
 %>
 <%page args="course" expression_filter="h"/>
+<% details = CourseDetails.fetch(course.id) %>
 <article class="course" id="${course.id}" role="region" aria-label="${course.display_name_with_default}">
   <a href="${reverse('about_course', args=[course.id.to_deprecated_string()])}">
     <header class="course-image">
@@ -18,6 +20,20 @@ from django.core.urlresolvers import reverse
         <span class="course-organization">${course.display_org_with_default}</span>
         <span class="course-code">${course.display_number_with_default}</span>
         <span class="course-title">${course.display_name_with_default}</span>
+        % if details.short_description:
+        <div class="course-short-description">${details.short_description}</div>
+        % endif
+        % if details.duration:
+        <div class="course-short-duration">${details.duration}</div>
+        % endif
+        % if course.format:
+        <div class="course-format">${course.format}</div>
+        % endif
+        % if course.certified:
+        <div class="course-certified">
+          ${_("Verified Certificate available:")} ${_("Yes") if course.certified else _("No")}
+        </div>
+        % endif
       </h2>
       <%
       if course.start is not None:

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -26,8 +26,8 @@ from openedx.core.djangoapps.models.course_details import CourseDetails
         % if details.duration:
         <div class="course-short-duration">${details.duration}</div>
         % endif
-        % if course.format:
-        <div class="course-format">${course.format}</div>
+        % if course.vendor:
+        <div class="course-vendor">${course.vendor}</div>
         % endif
         % if course.certified:
         <div class="course-certified">

--- a/lms/templates/courses_list.html
+++ b/lms/templates/courses_list.html
@@ -18,9 +18,9 @@ from course_modes.models import CourseMode
           for course in courses:
               mongo_course = modulestore().get_course(course.id, depth=0)
               if getattr(mongo_course, 'index_visible'):
-                  # add `format` attr to course:
-                  course_format = getattr(mongo_course, 'course_format')
-                  course.format = course_format
+                  # add `vendor` attr to course:
+                  course_vendor = getattr(mongo_course, 'course_vendor')
+                  course.vendor = course_vendor
                   # add `certified` bool attr to course:
                   mode_slugs = [mode.slug for mode in CourseMode.modes_for_course(course.id)]
                   certified = bool(set(mode_slugs) & {CourseMode.AUDIT, CourseMode.HONOR, CourseMode.VERIFIED})

--- a/lms/templates/courses_list.html
+++ b/lms/templates/courses_list.html
@@ -1,6 +1,10 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='static_content.html'/>
 <%! from django.utils.translation import ugettext as _ %>
+<%
+from xmodule.modulestore.django import modulestore
+from course_modes.models import CourseMode
+%>
 
 <section class="courses-container">
   <section class="highlighted-courses">
@@ -9,11 +13,29 @@
       <section class="courses">
         <ul class="courses-listing">
           ## limiting the course number by using HOMEPAGE_COURSE_MAX as the maximum number of courses
-          %for course in courses[:settings.HOMEPAGE_COURSE_MAX]:
-          <li class="courses-listing-item">
+        <%
+          visible_courses = []
+          for course in courses:
+              mongo_course = modulestore().get_course(course.id, depth=0)
+              if getattr(mongo_course, 'index_visible'):
+                  # add `format` attr to course:
+                  course_format = getattr(mongo_course, 'course_format')
+                  course.format = course_format
+                  # add `certified` bool attr to course:
+                  mode_slugs = [mode.slug for mode in CourseMode.modes_for_course(course.id)]
+                  certified = bool(set(mode_slugs) & {CourseMode.AUDIT, CourseMode.HONOR, CourseMode.VERIFIED})
+                  course.certified = certified
+
+                  visible_courses.append(course)
+
+              if len(visible_courses) == settings.HOMEPAGE_COURSE_MAX:
+                  break
+        %>
+          % for course in visible_courses:
+            <li class="courses-listing-item">
               <%include file="course.html" args="course=course" />
-          </li>
-        %endfor
+            </li>
+          % endfor
         </ul>
       </section>
     ## in case there are courses that are not shown on the homepage, a 'View all Courses' link should appear
@@ -21,7 +43,7 @@
       <div class="courses-more">
         <a class="courses-more-cta" href="${marketing_link('COURSES')}"> ${_("View all Courses")} </a>
       </div>
-    % endif
+      % endif
     % endif
 
   </section>


### PR DESCRIPTION
The PR adds additional info about a course in LMS index page courses list:
- course duration (Settings > Schedule & Details);
- course format (new Advanced setting: select: "Online" | "Offline");
- index visible (does course appear on the index page? - new Advanced setting: select: True | False);
- certification info: whether course in AUDIT | HONOR | VERIFIED mode;

**Youtrack:** https://youtrack.raccoongang.com/issue/RN-12

**Configuration instructions:** 
In order to restrict the number of displayed courses, the `HOMEPAGE_COURSE_MAX` setting must be used.
```
# lms.env.json
HOMEPAGE_COURSE_MAX = 6
```
#### Advanced settings
![Advanced settings](https://content.screencast.com/users/VolodymyrBergman/folders/Snagit/media/ec73d91f-87a8-4770-90df-0fe191523bec/2018-06-19_16-23-17.png)

#### Settings > Schedule & Details
![Settings](https://content.screencast.com/users/VolodymyrBergman/folders/Snagit/media/bf8bc180-365c-4cdc-896e-dbea7ec2cf3f/2018-06-19_16-27-29.png)

**Reviewers:**
@oksana-slu 