### PR TITLE
AuthorizeNet Accept Hosted Form payment processor

### DIFF
--- a/lms/djangoapps/shoppingcart/processors/AuthorizeNetProcessor.py
+++ b/lms/djangoapps/shoppingcart/processors/AuthorizeNetProcessor.py
@@ -1,0 +1,339 @@
+"""
+AuthorizeNet Accept Hosted Form payment processor
+
+
+IMPORTANT!!
+In manage.py comment this lines:
+
+#from safe_lxml import defuse_xml_libs
+#defuse_xml_libs()
+
+with uncommented code you you'll
+get an import error lxml.objectify from authorizenet module
+
+
+Configuration:
+
+FEATURES['ENABLE_PAYMENT_FAKE'] = False
+
+CC_PROCESSOR_NAME = 'AuthorizeNetProcessor'
+CC_PROCESSOR = {
+    'AuthorizeNetProcessor': {
+        'TEST_MODE': False,
+        'API_LOGIN_ID': '1239qK3nK7',
+        'TRANSACTION_KEY': '432hf54GchuYJ349Na',
+    }
+}
+
+"""
+import json
+import logging
+from urlparse import urljoin
+
+import re
+from authorizenet import apicontractsv1
+from authorizenet.apicontrollers import getHostedPaymentPageController, getTransactionDetailsController
+from authorizenet.constants import constants
+from django.conf import settings
+from django.templatetags.static import static
+
+from edxmako.shortcuts import render_to_string
+from shoppingcart.models import Order, OrderItem
+from shoppingcart.processors.exceptions import CCProcessorDataException, CCProcessorWrongAmountException, \
+    CCProcessorException
+from shoppingcart.processors.helpers import get_processor_config
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+log = logging.getLogger(__name__)
+
+ORDER_PREFIX = 'A001'
+
+RESPONSE_CODES = (
+    (1, 'Approved'),
+    (2, 'Declined'),
+    (3, 'Error'),
+    (4, 'Held for Review'),
+)
+
+
+def get_merchant_auth():
+    merchantAuth = apicontractsv1.merchantAuthenticationType()
+    merchantAuth.name = get_processor_config()['API_LOGIN_ID']
+    merchantAuth.transactionKey = get_processor_config()['TRANSACTION_KEY']
+    return merchantAuth
+
+
+def render_purchase_form_html(cart, callback_url=None, extra_data=None):
+    test_mode = get_processor_config().get('TEST_MODE', False)
+    payment_url = 'https://{}.authorize.net/payment/payment'.format('test' if test_mode else 'accept')
+
+    settings = apicontractsv1.ArrayOfSetting()
+
+    def add_settings(name, value):
+        setting = apicontractsv1.settingType()
+        setting.settingName = getattr(apicontractsv1.settingNameEnum, name)
+        setting.settingValue = json.dumps(value)
+        settings.setting.append(setting)
+
+    add_settings('hostedPaymentBillingAddressOptions', {
+        'show': False,
+    })
+    add_settings('hostedPaymentIFrameCommunicatorUrl', {
+        'url': urljoin(callback_url, static('IFrameCommunicator.html')),
+    })
+    add_settings('hostedPaymentReturnOptions', {
+        'showReceipt': False,
+        'cancelUrl': urljoin(callback_url, static('IFrameCommunicator.html')),
+    })
+
+    transactionrequest = apicontractsv1.transactionRequestType()
+    transactionrequest.transactionType = 'authCaptureTransaction'
+    transactionrequest.amount = cart.total_cost
+
+    items = OrderItem.objects.filter(order=cart.id).select_subclasses()
+    if len(items) == 1:
+        transactionrequest.description = items[0].line_desc
+    else:
+        line_items = apicontractsv1.ArrayOfLineItem()
+        for item in items:
+            line_item = apicontractsv1.lineItemType()
+            line_item.itemId = 'ITEM{}'.format(item.id)
+            line_item.name = 'item'
+            line_item.description = item.line_desc
+            line_item.quantity = '{}'.format(item.qty)
+            line_item.unitPrice = '{}'.format(item.unit_cost)
+            line_items.lineItem.append(line_item)
+        transactionrequest.lineItems = line_items
+
+    order = apicontractsv1.orderType()
+    order.invoiceNumber = '{}{:05}'.format(ORDER_PREFIX, cart.id)
+    transactionrequest.order = order
+
+    paymentPageRequest = apicontractsv1.getHostedPaymentPageRequest()
+    paymentPageRequest.merchantAuthentication = get_merchant_auth()
+    paymentPageRequest.transactionRequest = transactionrequest
+    paymentPageRequest.hostedPaymentSettings = settings
+
+    paymentPageController = getHostedPaymentPageController(paymentPageRequest)
+    paymentPageController.setenvironment(constants.SANDBOX if test_mode else constants.PRODUCTION)
+    paymentPageController.execute()
+    paymentPageResponse = paymentPageController.getresponse()
+
+    return render_to_string('shoppingcart/authorize_net/purchase_form.html', {
+        'action': payment_url,
+        'token': paymentPageResponse.token,
+        'callback_url': callback_url,
+    })
+
+
+def process_postpay_callback(params, **kwargs):
+    transactionDetailsRequest = apicontractsv1.getTransactionDetailsRequest()
+    transactionDetailsRequest.merchantAuthentication = get_merchant_auth()
+    transactionDetailsRequest.transId = params['transId']
+
+    transactionDetailsController = getTransactionDetailsController(transactionDetailsRequest)
+    transactionDetailsController.execute()
+    transactionDetailsResponse = transactionDetailsController.getresponse()
+
+    if params['orderInvoiceNumber'] != transactionDetailsResponse.transaction.order.invoiceNumber:
+        raise CCProcessorException
+
+    result = {
+        'order_id': int(unicode(transactionDetailsResponse.transaction.order.invoiceNumber)[len(ORDER_PREFIX):]),
+        'auth_amount': transactionDetailsResponse.transaction.authAmount,
+        'currency': 'USD',
+        'decision': transactionDetailsResponse.transaction.responseCode,
+        'card_number': unicode(transactionDetailsResponse.transaction.payment.creditCard.cardNumber),
+    }
+
+    try:
+        result = _payment_accepted(
+            result['order_id'],
+            result['auth_amount'],
+            result['currency'],
+            result['decision'],
+        )
+        if result['accepted']:
+            _record_purchase(params, result['order'])
+            return {
+                'success': True,
+                'order': result['order'],
+                'error_html': ''
+            }
+        else:
+            _record_payment_info(params, result['order'])
+            return {
+                'success': False,
+                'order': result['order'],
+                'error_html': _get_processor_decline_html(params)
+            }
+    except CCProcessorException as error:
+        log.exception('error processing AuthorizeNet postpay callback')
+        # if we have the order and the id, log it
+        if hasattr(error, 'order'):
+            _record_payment_info(params, error.order)
+        else:
+            log.info(json.dumps(params))
+        payment_support_email = configuration_helpers.get_value('payment_support_email', settings.PAYMENT_SUPPORT_EMAIL)
+        return {
+            'success': False,
+            'order': None,  # due to exception we may not have the order
+            'error_html': _(
+                u"Sorry! Your payment could not be processed because an unexpected exception occurred. "
+                u"Please contact us at {email} for assistance."
+            ).format(email=payment_support_email)
+        }
+
+
+def _record_payment_info(params, order):
+    """
+    Record the purchase and run purchased_callbacks
+
+    Args:
+        params (dict): The parameters we received from AuthorizeNet.
+
+    Returns:
+        None
+    """
+    if settings.FEATURES.get("LOG_POSTPAY_CALLBACKS"):
+        log.info(
+            "Order %d processed (but not completed) with params: %s", order.id, json.dumps(params)
+        )
+
+    order.processor_reply_dump = json.dumps(params)
+    order.save()
+
+
+def _record_purchase(params, order):
+    """
+    Record the purchase and run purchased_callbacks
+
+    Args:
+        params (dict): The parameters we received from AuthorizeNet.
+        order (Order): The order associated with this payment.
+
+    Returns:
+        None
+
+    """
+    # Usually, the credit card number will have the form "xxxxxxxx1234"
+    # Parse the string to retrieve the digits.
+    # If we can't find any digits, use placeholder values instead.
+    ccnum_str = params.get('card_number', '')
+    first_digit = re.search(r"\d", ccnum_str)
+    if first_digit:
+        ccnum = ccnum_str[first_digit.start():]
+    else:
+        ccnum = "####"
+
+    if settings.FEATURES.get("LOG_POSTPAY_CALLBACKS"):
+        log.info(
+            "Order %d purchased with params: %s", order.id, json.dumps(params)
+        )
+
+    # Mark the order as purchased and store the billing information
+    order.purchase(
+        first=params.get('bill_first_name', ''),
+        last=params.get('bill_last_name', ''),
+        street1=params.get('bill_address_line1', ''),
+        street2=params.get('bill_address_line2', ''),
+        city=params.get('bill_city', ''),
+        state=params.get('bill_state', ''),
+        country=params.get('bill_country', ''),
+        postalcode=params.get('bill_postal_code', ''),
+        ccnum=ccnum,
+        cardtype=params.get('card_type', ''),
+        processor_reply_dump=json.dumps(params)
+    )
+
+
+def _payment_accepted(order_id, auth_amount, currency, decision):
+    """
+    Check that AuthorizeNet has accepted the payment.
+
+    Args:
+        order_num (int): The ID of the order associated with this payment.
+        auth_amount (Decimal): The amount the user paid using AuthorizeNet.
+        currency (str): The currency code of the payment.
+        decision (str): "ACCEPT" if the payment was accepted.
+
+    Returns:
+        dictionary of the form:
+        {
+            'accepted': bool,
+            'amt_charged': int,
+            'currency': string,
+            'order': Order
+        }
+
+    Raises:
+        CCProcessorDataException: The order does not exist.
+        CCProcessorWrongAmountException: The user did not pay the correct amount.
+
+    """
+    try:
+        order = Order.objects.get(id=order_id)
+    except Order.DoesNotExist:
+        raise CCProcessorDataException(_("The payment processor accepted an order whose number is not in our system."))
+
+    if dict(RESPONSE_CODES)[decision] == 'Approved':
+        if auth_amount == order.total_cost and currency.lower() == order.currency.lower():
+            return {
+                'accepted': True,
+                'amt_charged': auth_amount,
+                'currency': currency,
+                'order': order
+            }
+        else:
+            ex = CCProcessorWrongAmountException(
+                _(
+                    u"The amount charged by the processor {charged_amount} {charged_amount_currency} is different "
+                    u"than the total cost of the order {total_cost} {total_cost_currency}."
+                ).format(
+                    charged_amount=auth_amount,
+                    charged_amount_currency=currency,
+                    total_cost=order.total_cost,
+                    total_cost_currency=order.currency
+                )
+            )
+
+            ex.order = order
+            raise ex
+    else:
+        return {
+            'accepted': False,
+            'amt_charged': 0,
+            'currency': 'usd',
+            'order': order
+        }
+
+
+def _get_processor_decline_html(params):
+    """
+    Return HTML indicating that the user's payment was declined.
+
+    Args:
+        params (dict): Parameters we received from AuthorizeNet.
+
+    Returns:
+        unicode: The rendered HTML.
+
+    """
+    payment_support_email = configuration_helpers.get_value('payment_support_email', settings.PAYMENT_SUPPORT_EMAIL)
+    return (
+        _(
+            "Sorry! Our payment processor did not accept your payment.  "
+            "The decision they returned was {decision}, "
+            "and the reason was {reason}.  "
+            "You were not charged. Please try a different form of payment.  "
+            "Contact us with payment-related questions at {email}."
+        ).format(
+            decision='<span class="decision">{decision}</span>'.format(decision=params['decision']),
+            reason='<span class="reason">{reason_code}:{reason_msg}</span>'.format(
+                reason_code=params['reason_code'],
+                reason_msg=params['reason_message'],
+            ),
+            email=payment_support_email
+        ),
+    )

--- a/lms/djangoapps/shoppingcart/static/IFrameCommunicator.html
+++ b/lms/djangoapps/shoppingcart/static/IFrameCommunicator.html
@@ -1,0 +1,51 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+ <title>AuthorizeNet IFrame Communicator</title>
+
+ <!--
+  To securely communicate between our Accept Hosted form and your web page,
+  we need a communicator page which will be hosted on your site alongside
+  your checkout/payment page. You can provide the URL of the communicator
+  page in your token request, which will allow Authorize.Net to embed the
+  communicator page in the payment form, and send JavaScript messaging through
+  your communicator page to a listener script on your main page.
+
+  This page contains a JavaScript that listens for events from the payment
+  form and passes them to an event listener in the main page.
+-->
+
+
+ <script type="text/javascript">
+
+ function callParentFunction(str) {
+   if (str && str.length > 0 && window.parent && window.parent.parent 
+     && window.parent.parent.CommunicationHandler && window.parent.parent.CommunicationHandler.onReceiveCommunication)
+   {
+      var referrer = document.referrer;
+      window.parent.parent.CommunicationHandler.onReceiveCommunication({qstr : str , parent : referrer});
+   }
+ }
+ 
+ function receiveMessage(event) {
+   if (event && event.data) {
+     callParentFunction(event.data);
+   }
+ }
+ 
+ if (window.addEventListener) {
+   window.addEventListener("cancel", receiveMessage, false);
+   window.addEventListener("message", receiveMessage, false);
+ } else if (window.attachEvent) {
+   window.attachEvent("oncancel", receiveMessage);
+   window.attachEvent("onmessage", receiveMessage);
+ }
+ 
+ if (window.location.hash && window.location.hash.length > 1) {
+   callParentFunction(window.location.hash.substring(1));
+ }
+
+ </script>
+ </head>
+ <body>
+ </body>
+ </html>

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -117,15 +117,14 @@ PIPELINE_SASS_ARGUMENTS = '--debug-info'
 ########################### VERIFIED CERTIFICATES #################################
 
 FEATURES['AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING'] = True
-FEATURES['ENABLE_PAYMENT_FAKE'] = True
+FEATURES['ENABLE_PAYMENT_FAKE'] = False
 
-CC_PROCESSOR_NAME = 'CyberSource2'
+CC_PROCESSOR_NAME = 'AuthorizeNetProcessor'
 CC_PROCESSOR = {
-    'CyberSource2': {
-        "PURCHASE_ENDPOINT": '/shoppingcart/payment_fake/',
-        "SECRET_KEY": 'abcd123',
-        "ACCESS_KEY": 'abcd123',
-        "PROFILE_ID": 'edx',
+    'AuthorizeNetProcessor': {
+        'TEST_MODE': True,
+        'API_LOGIN_ID': '39qK3nK7',
+        'TRANSACTION_KEY': '4hf54GchuYJ349Na',
     }
 }
 

--- a/lms/templates/shoppingcart/authorize_net/purchase_form.html
+++ b/lms/templates/shoppingcart/authorize_net/purchase_form.html
@@ -1,0 +1,96 @@
+<%! from django.utils.translation import ugettext as _ %>
+<form action="${action}" method="post" target="payment_form" id="payment-button-form">
+    <input type="hidden" name="token" value="${token}"/>
+    <button type="submit">${_('Payment')}<span class="icon fa fa-caret-right" aria-hidden="true"></span></button>
+</form>
+
+<div id="payment-popup" class="white-popup mfp-hide">
+    <iframe name="payment_form" id="payment-form" scrolling="0"></iframe>
+</div>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/magnific-popup.min.css">
+<style type="text/css">
+    #payment-popup.white-popup {
+        position: relative;
+        padding: 0;
+        max-width: 600px;
+        height: 100%;
+        margin: 20px auto;
+        background: #FFF;
+        overflow: hidden;
+    }
+
+    #payment-popup iframe {
+        width: 100%;
+    }
+</style>
+
+<script type="text/javascript"
+        src="https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/jquery.magnific-popup.min.js"></script>
+<script type="text/javascript">
+    var magnific;
+
+    $('#payment-button-form').on('submit', function (e) {
+        magnific = $.magnificPopup.open({
+            items: {
+                src: '#payment-popup',
+                type: 'inline',
+            },
+            closeOnBgClick: false,
+        }, 0);
+    });
+
+    function parseQueryString(str) {
+        var vars = [];
+        var arr = str.split('&');
+        var pair;
+        for (var i = 0; i < arr.length; i++) {
+            pair = arr[i].split('=');
+            vars[pair[0]] = decodeURI(pair[1]);
+        }
+        return vars;
+    }
+
+    function post(path, params, method) {
+        method = method || "post"; // Set method to post by default if not specified.
+
+        // The rest of this code assumes you are not using a library.
+        // It can be made less wordy if you use one.
+        var form = document.createElement("form");
+        form.setAttribute("method", method);
+        form.setAttribute("action", path);
+
+        for (var key in params) {
+            if (params.hasOwnProperty(key)) {
+                var hiddenField = document.createElement("input");
+                hiddenField.setAttribute("type", "hidden");
+                hiddenField.setAttribute("name", key);
+                hiddenField.setAttribute("value", params[key]);
+
+                form.appendChild(hiddenField);
+            }
+        }
+
+        document.body.appendChild(form);
+        form.submit();
+    }
+
+    window.CommunicationHandler = {
+        onReceiveCommunication: function (argument) {
+            var params = parseQueryString(argument.qstr);
+            switch (params['action']) {
+                case 'cancel':
+                    $.magnificPopup.instance.close();
+                    break;
+                case 'resizeWindow':
+                    $('#payment-form').height(params['height']);
+                    break;
+                case 'transactResponse':
+                    post('${callback_url}', JSON.parse(params['response']));
+                    break;
+                default:
+                    break;
+            }
+        }
+    };
+</script>

--- a/manage.py
+++ b/manage.py
@@ -12,8 +12,8 @@ Any arguments not understood by this manage.py will be passed to django-admin.py
 """
 
 # Patch the xml libs before anything else.
-from safe_lxml import defuse_xml_libs
-defuse_xml_libs()
+#from safe_lxml import defuse_xml_libs
+#defuse_xml_libs()
 
 import os
 import sys

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -216,3 +216,5 @@ xblock==1.0.0
 
 # Third Party XBlocks
 edx-sga==0.6.2
+
+authorizenet==1.1.0


### PR DESCRIPTION
**Description:**
Add AuthorizeNet payment processor for standart edX shopping cart
using authorizenet module https://github.com/AuthorizeNet/sdk-python

**YouTrack link**
https://youtrack.raccoongang.com/issue/CALYPSO-17

**Configuration instructions:**
* register at https://account.authorize.net/ for production
* or https://sandbox.authorize.net/ for development
* go to `Settings` -> `API Credentials & Keys`
* generate your `Transaction Key` and `API Login ID`

```
FEATURES['ENABLE_PAYMENT_FAKE'] = False

CC_PROCESSOR_NAME = 'AuthorizeNetProcessor'
CC_PROCESSOR = {
    'AuthorizeNetProcessor': {
        'TEST_MODE': False,
        'API_LOGIN_ID': '1239qK3nK7',
        'TRANSACTION_KEY': '432hf54GchuYJ349Na',
    }
}
```
set `TEST_MODE` to `True` for fake payments

* go to `Settings`  -> `Silent Post URL`
* fill postpay_callback full url `/shoppingcart/postpay_callback/` for example `https://4807636a.ngrok.io/shoppingcart/postpay_callback/`


**Testing instructions:**

**Reviewers:**
- [x] @oksana-slu 
- [x] @rimikt

**Related Confluence documents:**

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation in source code updated
- [ ] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.

Commented code in file `manage.py` to avoid import error lxml.objectify from authorizenet module
```
#from safe_lxml import defuse_xml_libs
#defuse_xml_libs()
```
