### PR TITLE
comment out defuse_xml_libs() to avoid lxml objectify load error

### DIFF
--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -9,8 +9,8 @@ It exposes a module-level variable named ``application``. Django's
 """
 
 # Patch the xml libs
-from safe_lxml import defuse_xml_libs
-defuse_xml_libs()
+# from safe_lxml import defuse_xml_libs
+# defuse_xml_libs()
 
 # Disable PyContract contract checking when running as a webserver
 import contracts

--- a/lms/wsgi_apache_lms.py
+++ b/lms/wsgi_apache_lms.py
@@ -6,8 +6,8 @@ It exposes a module-level variable named ``application``.
 """
 
 # Patch the xml libs before anything else.
-from safe_lxml import defuse_xml_libs
-defuse_xml_libs()
+# from safe_lxml import defuse_xml_libs
+# defuse_xml_libs()
 
 import os
 


### PR DESCRIPTION
```python
2018-06-23 09:24:16,575 ERROR 2811 [django.request] base.py:256 - Internal Server Error: /shoppingcart/
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 22, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/shoppingcart/decorators.py", line 22, in func_wrapper
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/shoppingcart/views.py", line 204, in show_cart
    form_html = render_purchase_form_html(cart, callback_url=callback_url)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/shoppingcart/processors/__init__.py", line 39, in render_purchase_form_html
    return PROCESSOR_MODULE.render_purchase_form_html(cart, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/shoppingcart/processors/AuthorizeNetProcessor.py", line 120, in render_purchase_form_html
    paymentPageController.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/authorizenet/apicontrollersbase.py", line 159, in execute
    self._mainObject = objectify.fromstring(responseString)
AttributeError: 'module' object has no attribute 'fromstring'
```