### PR TITLE
Fix jenkins-report script, because pipeline syntaxis changed and its ignoring source in shell command (ginkgo-rg)

### DIFF
--- a/scripts/jenkins-report.sh
+++ b/scripts/jenkins-report.sh
@@ -5,14 +5,18 @@ set -e
 # reports this data to codecov.io. The following environment variables must be
 # set in order to report to codecov:
 # CODE_COV_TOKEN: CodeCov API token
-# CI_BRANCH: The branch that the coverage report describes
+# TARGET_BRANCH: THe branch that the coverage report targets
+# SOURCE_BRANCH: The branch that the coverage report describes
 
 # This script is used by the edx-platform-unit-coverage jenkins job.
 
 source scripts/jenkins-common.sh
 
+TARGET_BRANCH=${TARGET_BRANCH:="origin/master"}
+SOURCE_BRANCH=${SOURCE_BRANCH:=""}
+
 # Get the diff coverage and html reports for unit tests
-paver coverage
+paver coverage -b $TARGET_BRANCH
 
 # Test for the CodeCov API token
 if [ -z $CODE_COV_TOKEN ]; then
@@ -20,8 +24,8 @@ if [ -z $CODE_COV_TOKEN ]; then
     echo "This must be set as an environment variable if order to report coverage"
 else
     # Send the coverage data to codecov
-    pip install codecov==2.0.5
-    codecov --token=$CODE_COV_TOKEN --branch=$CI_BRANCH
+    pip install codecov==2.0.15
+    codecov --token=$CODE_COV_TOKEN --branch=$SOURCE_BRANCH
 fi
 
 # JUnit test reporter will fail the build


### PR DESCRIPTION
**Description:** Fix for new pipeline version + upgrade codecov version.

**Youtrack:** https://youtrack.raccoongang.com/issue/DOI-91

**Merge deadline:** 27.06.18

**Reviewers:**
- [ @a-kryachko ]
- [ @dgamanenko ] 
- [ @AndreyLykhoman ]

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Commits are squashed

**Post merge:**
- [x] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
