### PR TITLE
Broad notifications

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -581,14 +581,15 @@
                 return this.retrieveFirstPage();
             };
 
-            DiscussionThreadListView.prototype.updateEmailNotifications = function() {
+            DiscussionThreadListView.prototype.updateEmailNotifications = function(evt) {
                 var $checkbox, checked, urlName;
-                $checkbox = $('input.email-setting');
+                $checkbox = $(evt.target);
                 checked = $checkbox.prop('checked');
                 urlName = (checked) ? 'enable_notifications' : 'disable_notifications';
                 DiscussionUtil.safeAjax({
                     url: DiscussionUtil.urlFor(urlName),
                     type: 'POST',
+                    data: $checkbox.prop('name') === 'broad-email-notification' ? {broad: true} : {},
                     error: function() {
                         $checkbox.prop('checked', !checked);
                     }

--- a/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
+++ b/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
@@ -170,12 +170,22 @@
                 HtmlUtils.append(this.$('.forum-content').empty(), HtmlUtils.template(discussionHomeTemplate)({}));
                 this.$('.forum-nav-thread-list a').removeClass('is-active').find('.sr')
                     .remove();
-                this.$('input.email-setting').bind('click', this.discussionThreadListView.updateEmailNotifications);
+                this.$('#email-setting-checkbox').bind('click', this.discussionThreadListView.updateEmailNotifications);
+                this.$('#broad-email-setting-checkbox')
+                  .bind('click', this.discussionThreadListView.updateEmailNotifications);
                 DiscussionUtil.safeAjax({
                     url: url,
                     type: 'GET',
                     success: function(response) {
-                        $('input.email-setting').prop('checked', response.status);
+                        $('#email-setting-checkbox').prop('checked', response.status);
+                    }
+                });
+                DiscussionUtil.safeAjax({
+                    url: url,
+                    type: 'GET',
+                    data: {broad: true},
+                    success: function(response) {
+                        $('#broad-email-setting-checkbox').prop('checked', response.status);
                     }
                 });
             },

--- a/lms/djangoapps/discussion/static/discussion/templates/discussion-home.underscore
+++ b/lms/djangoapps/discussion/static/discussion/templates/discussion-home.underscore
@@ -47,14 +47,39 @@
       <tr class="helpgrid-row helpgrid-row-notification">
         <th scope="row" class="row-title"><%- gettext('Receive updates') %></td>
         <td class="row-item-full" colspan="3">
-          <label for="email-setting-checkbox">
-            <span class="sr"><%- gettext("Toggle Notifications Setting") %></span>
-            <span class="notification-checkbox">
-              <input type="checkbox" id="email-setting-checkbox" class="email-setting" name="email-notification"/>
-              <span class="icon fa fa-envelope" aria-hidden="true"></span>
+          <div>
+              <label for="email-setting-checkbox">
+                <span class="sr"><%- gettext("Toggle Notifications Setting") %></span>
+                <span class="notification-checkbox">
+                  <input type="checkbox" id="email-setting-checkbox" class="email-setting" name="email-notification"/>
+                  <span class="icon fa fa-envelope" aria-hidden="true"></span>
+                </span>
+              </label>
+            <span class="row-description">
+                <%- gettext("Check this box to receive an email digest once a day notifying you about new, unread activity from posts you are following.") %>
             </span>
-          </label>
-          <span class="row-description"><%- gettext("Check this box to receive an email digest once a day notifying you about new, unread activity from posts you are following.") %></span>
+          </div>
+          <div class="broad-mode">
+              <label for="broad-email-setting-checkbox">
+                <span class="notification-checkbox">
+                  <input type="checkbox"
+                         id="broad-email-setting-checkbox"
+                         class="email-setting"
+                         name="broad-email-notification"
+                  />
+                  <span class="icon fa fa-bell" aria-hidden="true"></span>
+                </span>
+              </label>
+              <span class="row-description">
+                <%= HtmlUtils.interpolateHtml(
+                    gettext("This checkbox enables notifications' \"broad mode\": an email digest will include extra section with {boldStarts}all unread activities{boldEnds}."),
+                    {
+                      boldStarts: HtmlUtils.HTML('<b>'),
+                      boldEnds: HtmlUtils.HTML('</b>')
+                    }
+                )%>
+              </span>
+          </div>
         </td>
       </tr>
     </table>

--- a/lms/djangoapps/notification_prefs/__init__.py
+++ b/lms/djangoapps/notification_prefs/__init__.py
@@ -1,1 +1,2 @@
 NOTIFICATION_PREF_KEY = "notification_pref"
+BROAD_NOTIFICATION_PREF_KEY = "broad_notification_pref"

--- a/lms/djangoapps/notifier_api/serializers.py
+++ b/lms/djangoapps/notifier_api/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from openedx.core.djangoapps.course_groups.cohorts import is_course_cohorted
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 
-from lms.djangoapps.notification_prefs import NOTIFICATION_PREF_KEY
+from lms.djangoapps.notification_prefs import NOTIFICATION_PREF_KEY, BROAD_NOTIFICATION_PREF_KEY
 
 
 class NotifierUserSerializer(serializers.ModelSerializer):
@@ -36,7 +36,7 @@ class NotifierUserSerializer(serializers.ModelSerializer):
             pref.key: pref.value
             for pref
             in user.preferences.all()
-            if pref.key in [LANGUAGE_KEY, NOTIFICATION_PREF_KEY]
+            if pref.key in [LANGUAGE_KEY, NOTIFICATION_PREF_KEY, BROAD_NOTIFICATION_PREF_KEY]
         }
 
     def get_course_info(self, user):

--- a/lms/djangoapps/notifier_api/views.py
+++ b/lms/djangoapps/notifier_api/views.py
@@ -3,7 +3,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework.response import Response
 from rest_framework import pagination
 
-from notification_prefs import NOTIFICATION_PREF_KEY
+from notification_prefs import NOTIFICATION_PREF_KEY, BROAD_NOTIFICATION_PREF_KEY
 from notifier_api.serializers import NotifierUserSerializer
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 
@@ -39,7 +39,7 @@ class NotifierUsersViewSet(ReadOnlyModelViewSet):
 
     # See NotifierUserSerializer for notes about related tables
     queryset = User.objects.filter(
-        preferences__key=NOTIFICATION_PREF_KEY
+        preferences__key=BROAD_NOTIFICATION_PREF_KEY
     ).select_related(
         "profile"
     ).prefetch_related(

--- a/lms/static/sass/discussion/views/_home.scss
+++ b/lms/static/sass/discussion/views/_home.scss
@@ -159,5 +159,10 @@
   .helpgrid-row-notification {
     .fa-square {color: $green;}
     .fa-envelope {color: $light-gray;}
+    .fa-bell {color: $light-gray;}
+  }
+
+  div.broad-mode {
+    margin-top: 2px;
   }
 }

--- a/lms/templates/unsubscribe.html
+++ b/lms/templates/unsubscribe.html
@@ -23,7 +23,7 @@ from django.conf import settings
         )).format(
             platform_name=settings.PLATFORM_NAME,
             dashboard_link_start=HTML("<a href='{}'>").format(reverse('dashboard')),
-            undo_link_start=HTML("<a id='resub_link' href='{}'>").format(reverse('resubscribe_forum_update', args=[token])),
+            undo_link_start=HTML("<a id='resub_link' href='{}?broad={}'>").format(reverse('resubscribe_forum_update', args=[token]), broad),
             link_end=HTML("</a>"),
         )}
     </p>


### PR DESCRIPTION
## Detailed description for `Broad notifications` feature.

### What is it about?

Vanilla OpenEdx platform has daily digest feature - in the LMS in Discussions tab user can subscribe (by checking `envelop icon` checkbox) for daily email updates from the forum threads her is following. All new activities from followed threads will be emailed to such user ones a day. **This subscription is common for all courses user is enrolled.**

_New feature => BROAD notifications:_

Adds new `bell icon` checkbox next to the standard `envelop icon` which enables new kind of subscription - a user will receive daily digest email with **all new activities from the courses she is enrolled (regardless whether forum thread is followed or not)** - some kind of `greedy` notification mode. But **private cohorts activities are honored**.

Broad notification feature is completely independent of vanilla notifications.

### Testing

(Disclaimer: unit tests not checked at all)

Visual feature identification: LMS => Discussion tab => new `bell icon` checkbox appears
![visualization](https://content.screencast.com/users/VolodymyrBergman/folders/Snagit/media/456f47fa-0341-4e9e-8118-0abaf12b8ef5/2018-07-02_11-54-45.png)

Designed behavior:

1) a User enters Discussion tab and checks new `bell icon` checkbox;
2) `bell` checkbox is enabled in all User courses;
3) ones a day User receives an email with `BROAD VERSION` forum digest;
4) broad digest includes all new forum activities (posts, responses, comments) from the courses User is enrolled in;
4.1) public threads activities are included;
4.2) private (cohort-specific) activities from User's cohort are included;
4.3) private (cohort-specific) activities from other cohorts **are absent**;

### Tech notes

#### Touched platform apps:

- `lms` => templates;
- `lms/djangoapps/discussion` => frontend: js-views, templates, styles;
- `lms/djangoapps/notification_prefs` => 
  - new preferences key added (BROAD_NOTIFICATION_PREF_KEY = "broad_notification_pref");
  - py-views;
- `lms/djangoapps/notifier_api` => serializer, py-views;

#### CODEBASE: 
- [Platform patch](https://github.com/raccoongang/edx-platform/tree/icnc-broad-notifications);
- [Notifier patch](https://github.com/raccoongang/notifier/tree/icnc-broad-notifications);
- [Forum patch](https://github.com/raccoongang/cs_comments_service/tree/icnc-broad-notifications);