### PR TITLE
fixed unhandled exception in instructor task for profile information report generation for users with no profile

### DIFF
--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -253,7 +253,11 @@ def enrolled_students_features(course_key, features):
 
         student_dict = dict((feature, extract_attr(student, feature))
                             for feature in student_features)
-        profile = student.profile
+        try:
+            profile = student.profile
+        except ObjectDoesNotExist:
+            profile = None
+
         if profile is not None:
             profile_dict = dict((feature, extract_attr(profile, feature))
                                 for feature in profile_features)


### PR DESCRIPTION
**Description:** Fix for error while generating ```Instructor -> Data Download -> Generate Grade Report``` after execution of edx-configuration role ```demo``` 

**Youtrack:** https://youtrack.raccoongang.com/issue/NRG-50

**Testing instructions:**

1. Deploy ```demo``` role from edx-configuration repository
2. Log into LMS as staff
2. Generate report in ```Instructor -> Data Download -> Generate Grade Report``` on Edx Demo Course
3. Expect report is able to download as .csv file
4. If ERROR 500 happened instead - check failed.

