### PR TITLE
[DIDACTICUM-46] use path without get params

### DIFF
--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -74,7 +74,7 @@ class AuthorizationCheckMiddleware(object):
                 request.method == 'GET' and
                 not request.user.is_authenticated() and
                 '/admin' not in request.get_full_path() and
-                'signin_user' != resolve(request.get_full_path()).url_name
+                'signin_user' != resolve(request.path).url_name
 
         ):
             return HttpResponseRedirect(reverse('signin_user'))


### PR DESCRIPTION
**Description:** Page not found click at the "Sign In " in login page. 'resolve'  method does't find name of url because 'signin_user' url has this pattern '^login$' but 'resolve' method has '/login?next=%2Fdashboard'.  'get_full_path() ' method makes this string.

Solving: Using '.path' param instead 'get_full_path()'.  '.path' param gets url without 'GET' params.


**Youtrack:** https://youtrack.raccoongang.com/issue/DIDACTICUM-46

