### PR TITLE
[FLANE-57] Revert wrong OIDC configuration

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -943,8 +943,7 @@ OIDC_PROVIDERS = {
         'client_registration': {
             'client_id': FEATURES.get('OIDC_CLIENT_ID'),
             'client_secret': FEATURES.get('OIDC_CLIENT_SECRET'),
-            'redirect_uris': ['{}/openid/callback/login/'.format(LMS_ROOT_URL),
-                              '{}://{}/openid/callback/login/'.format(scheme, FEATURES.get('PREVIEW_LMS_BASE', ''))],
+            "redirect_uri": "%s://{}/openid/callback/login/" % scheme,
             'post_logout_redirect_uris': ['{}/openid/callback/logout/'.format(LMS_ROOT_URL)],
        },
    }


### PR DESCRIPTION
Changes:
- Revert wrong commit bbf25c450d113ed94ca6c31c47835beddc53b006
- apply correct configuration settings for django-oidc from branch 
https://github.com/raccoongang/django-oidc/tree/sso-microsites

**Description:**
OIDC configuration in aws.py has wrong setting `redirect_uris`.
New django-oidc should be merged to master to apply this fix on production.

**Details**
On stage new django-oidc version is deployed so the configuration should be `redirect_uri`.
On production deployed old version. So we need to plan upgrade for django-oidc production version.

**Youtrack:** 
[FLANE-57](https://youtrack.raccoongang.com/issue/FLANE-57)
