### PR TITLE
[CB-83] Fix default CUSTOM_OAUTH_PARAMS in settings.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -401,7 +401,7 @@ FEATURES = {
 }
 
 # Setting parameters which are required for the custom oauth backend
-CUSTOM_OAUTH_PARAMS = None
+CUSTOM_OAUTH_PARAMS = {}
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews
 COURSE_REVIEWS_TOOL_PROVIDER_FRAGMENT_NAME = 'coursetalk-reviews-fragment.html'


### PR DESCRIPTION
Recently, under the case, ENABLE_CUSTOM_OAUTH_BACKEND is False and CUSTOM_OAUTH_PARAMS is not set up, an AttributeError exception is raised during the devstack deployment.