### PR TITLE
[CAMARA] Camara ginkgo stage dinamic placeholder

### DIFF
--- a/lms/templates/mpesa/mpesa_form.html
+++ b/lms/templates/mpesa/mpesa_form.html
@@ -3,6 +3,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.conf import settings
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <%block name="pagetitle">${_("Shopping cart")}</%block>
 
@@ -15,8 +16,10 @@ from django.conf import settings
         % for pk, pv in params.iteritems():
             <input type="hidden" name="${pk}" value="${pv}" />
         % endfor
-
-        <input type="text" name="phone" id="phone" placeholder="${_('Your phone number')}" required="required" >
+        <%
+            placeholder = configuration_helpers.get_value('PLACEHOLDER', _('Your phone number') )
+        %>
+        <input type="text" name="phone" id="phone" placeholder="${placeholder}" required="required" >
         <button id="submit" type="submit" class="button postfix discovery-submit">
             <div id="button_text">${_('Payment')}</div>
             <div aria-live="polite" aria-relevant="all">


### PR DESCRIPTION
**Description:** The solution for Change placeholder in phone field in MPESA payment form.  Added site's setting "PLACEHOLDER" and checked it in a template. If it is absent that placeholder has 'Your phone number' string.

**Youtrack:** https://youtrack.raccoongang.com/issue/CAMARA-87

**Configuration instructions:** 
In admin page in siteconfiguration section ( "/admin/site_configuration/siteconfiguration" ) you need to add this setting that contains placeholder. Example:
{
...
"PLACEHOLDER":"2547XXXXXXXX"
...
}