### PR TITLE
[CAMARA] Fix validate_int function for  in firefox and chrome

### DIFF
--- a/lms/templates/mpesa/mpesa_form.html
+++ b/lms/templates/mpesa/mpesa_form.html
@@ -42,12 +42,11 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 function validate_int(myEvento) {
   var myCaja = document.getElementById("phone");
   myText = myCaja.value;
-  if ((myEvento.charCode >= 48 && myEvento.charCode <= 57) && myText.length < 12) {
-    dato = true;
-  } else {
-    dato = false;
+  charCode = myEvento.charCode
+  if (charCode < 32 || (charCode >= 48 && charCode <= 57) && myText.length < 12){
+      return true;
   }
-  return dato;
+  return false;
 }
 
 document.getElementById("phone").onkeypress = validate_int;

--- a/lms/templates/mpesa/mpesa_form.html
+++ b/lms/templates/mpesa/mpesa_form.html
@@ -43,6 +43,8 @@ function validate_int(myEvento) {
   var myCaja = document.getElementById("phone");
   myText = myCaja.value;
   charCode = myEvento.charCode
+  // The statement allows writing only numbers.
+  // Firefox needs 'charCode == 0'  for work delete numbers.
   if (charCode == 0  || (charCode >= 48 && charCode <= 57) && myText.length < 12){
       return true;
   }

--- a/lms/templates/mpesa/mpesa_form.html
+++ b/lms/templates/mpesa/mpesa_form.html
@@ -43,7 +43,7 @@ function validate_int(myEvento) {
   var myCaja = document.getElementById("phone");
   myText = myCaja.value;
   charCode = myEvento.charCode
-  if (charCode < 32 || (charCode >= 48 && charCode <= 57) && myText.length < 12){
+  if (charCode == 0  || (charCode >= 48 && charCode <= 57) && myText.length < 12){
       return true;
   }
   return false;

--- a/lms/templates/mpesa/mpesa_form.html
+++ b/lms/templates/mpesa/mpesa_form.html
@@ -43,8 +43,8 @@ function validate_int(myEvento) {
   var myCaja = document.getElementById("phone");
   myText = myCaja.value;
   charCode = myEvento.charCode
-  // The statement allows writing only numbers.
-  // Firefox required 'charCode == 0'  for available to delete symbols.
+  // The statement allows write only numbers.
+  // Firefox required 'charCode == 0' for DELETE availability.
   if (charCode == 0  || (charCode >= 48 && charCode <= 57) && myText.length < 12){
       return true
   }

--- a/lms/templates/mpesa/mpesa_form.html
+++ b/lms/templates/mpesa/mpesa_form.html
@@ -44,9 +44,9 @@ function validate_int(myEvento) {
   myText = myCaja.value;
   charCode = myEvento.charCode
   // The statement allows writing only numbers.
-  // Firefox needs 'charCode == 0'  for work delete numbers.
+  // Firefox required 'charCode == 0'  for available to delete symbols.
   if (charCode == 0  || (charCode >= 48 && charCode <= 57) && myText.length < 12){
-      return true;
+      return true
   }
   return false;
 }


### PR DESCRIPTION
**Description:**  The user cannot delete number on phone field in MPESA form in Firefox browser. 
 The solution: I  added  'charCode < 32' to check the button's ASCII char code.

**Youtrack:** https://youtrack.raccoongang.com/issue/CAMARA-87
