### PR TITLE
Extra button `make programs` in CMS: course outline (next to `Reindex`)

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -335,10 +335,8 @@ def make_programs_handler(request):
     """
     The restful handler for initiating programs automated generation.
     GET
-        html: return status of indexing task
-        json: return status of indexing task
+        json: return feedback message about automated programs generation procedure
     """
-    new_programs_created = 0
     content_type = request.META.get('CONTENT_TYPE', None)
     if content_type is None:
         content_type = "application/json; charset=utf-8"

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -12,6 +12,7 @@ import six
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
@@ -22,6 +23,9 @@ from django.views.decorators.http import require_GET, require_http_methods
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import Location
+
+from openedx.core.djangoapps.catalog.models import CatalogIntegration
+from openedx.core.djangoapps.catalog.utils import create_catalog_api_client
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 
@@ -93,7 +97,7 @@ from .library import LIBRARIES_ENABLED, get_library_creator_status
 log = logging.getLogger(__name__)
 
 __all__ = ['course_info_handler', 'course_handler', 'course_listing',
-           'course_info_update_handler', 'course_search_index_handler',
+           'course_info_update_handler', 'course_search_index_handler', 'make_programs_handler',
            'course_rerun_handler',
            'settings_handler',
            'grading_handler',
@@ -322,6 +326,64 @@ def course_search_index_handler(request, course_key_string):
         return HttpResponse(dump_js_escaped_json({
             "user_message": _("Course has been successfully reindexed.")
         }), content_type=content_type, status=200)
+
+
+@login_required
+@ensure_csrf_cookie
+@require_GET
+def make_programs_handler(request):
+    """
+    The restful handler for initiating programs automated generation.
+    GET
+        html: return status of indexing task
+        json: return status of indexing task
+    """
+    new_programs_created = 0
+    content_type = request.META.get('CONTENT_TYPE', None)
+    if content_type is None:
+        content_type = "application/json; charset=utf-8"
+
+    try:
+        catalog_integration = CatalogIntegration.current()
+        username = catalog_integration.service_username
+        User = get_user_model()
+
+        try:
+            user = User.objects.get(username=username)
+            client = create_catalog_api_client(user)
+        except User.DoesNotExist:
+            log.error(
+                'Failed to create API client. Service user {username} does not exist.'.format(username)
+            )
+            raise
+
+        try:
+            log.info('Requesting program UUIDs.')
+            new_programs_created = client.make_programs.post()
+        except:  # pylint: disable=bare-except
+            log.error('Failed to initiate programs regeneration.')
+            raise
+
+    except IOError as exc:
+        return HttpResponse(dump_js_escaped_json({
+            "user_message": exc.message
+        }), content_type=content_type, status=500)
+
+    if new_programs_created:
+        user_message = _(
+            """Regeneration successful.
+            New {} programs were created.
+            Usually it takes up to 10 minutes before new programs are available on LMS.""".format(
+                new_programs_created
+            )
+        )
+    else:
+        user_message = _(
+            "Generation was successfully initiated, but no new programs were created."
+        )
+    return HttpResponse(dump_js_escaped_json({
+        "user_message": user_message
+    }), content_type=content_type, status=200)
 
 
 def _course_outline_json(request, course_module):
@@ -626,6 +688,8 @@ def course_index(request, course_key):
                     'action_state_id': current_action.id,
                 },
             ) if current_action else None,
+            'show_make_programs_button': bool(CourseOverview.get_from_id(course_key).effort),
+            'make_programs_link': reverse('make-programs-handler'),
         })
 
 

--- a/cms/static/js/views/pages/course_outline.js
+++ b/cms/static/js/views/pages/course_outline.js
@@ -28,6 +28,9 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'js/views
                 this.$('.button.button-reindex').click(function(event) {
                     self.handleReIndexEvent(event);
                 });
+                this.$('#button-make-programs').click(function(event) {
+                    self.handleMakeProgramsEvent(event);
+                });
                 this.model.on('change', this.setCollapseExpandVisibility, this);
                 $('.dismiss-button').bind('click', ViewUtils.deleteNotificationHandler(function() {
                     $('.wrapper-alert-announcement').removeClass('is-shown').addClass('is-hidden');
@@ -138,6 +141,43 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'js/views
             onIndexError: function(data) {
                 var msg = new NoteView.Error({
                     title: gettext('There were errors reindexing course.'),
+                    message: data.user_message
+                });
+                msg.show();
+            },
+
+            handleMakeProgramsEvent: function(event) {
+                var self = this;
+                event.preventDefault();
+                var target = $(event.currentTarget);
+                target.css('cursor', 'wait');
+                this.startMakePrograms(target.attr('href'))
+                    .done(function(data) { self.onMakeProgramsSuccess(data); })
+                    .fail(function(data) { self.onMakeProgramsError(data); })
+                    .always(function() { target.css('cursor', 'pointer'); });
+            },
+
+            startMakePrograms: function(makeProgramsHandlerUrl) {
+                return $.ajax({
+                    url: makeProgramsHandlerUrl,
+                    method: 'GET',
+                    global: false,
+                    contentType: 'application/json; charset=utf-8',
+                    dataType: 'json'
+                });
+            },
+
+            onMakeProgramsSuccess: function(data) {
+                var msg = new AlertView.Announcement({
+                    title: gettext('Programs Generator'),
+                    message: data.user_message
+                });
+                msg.show();
+            },
+
+            onMakeProgramsError: function(data) {
+                var msg = new NoteView.Error({
+                    title: gettext('There were errors initiating programs regeneration.'),
                     message: data.user_message
                 });
                 msg.show();

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -575,7 +575,7 @@
     &.requirements {
 
       #field-course-effort {
-        width: flex-grid(3, 9);
+        width: flex-grid(9, 9);
       }
     }
 

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -132,6 +132,13 @@ from openedx.core.djangolib.markup import HTML, Text
                         </a>
                     </li>
                 %endif
+                %if show_make_programs_button:
+                    <li class="nav-item">
+                        <a href="${make_programs_link}" class="button" data-category="programs" title="${_('Regenerate programs')}" id="button-make-programs">
+                            <span class="icon-arrow-right" aria-hidden="true"></span>${_('Make Programs')}
+                        </a>
+                    </li>
+                %endif
                 <li class="nav-item">
                     <a href="#" class="button button-toggle button-toggle-expand-collapse collapse-all is-hidden">
                         <span class="collapse-all"><span class="icon fa fa-arrow-up" aria-hidden="true"></span> <span class="label">${_("Collapse All Sections")}</span></span>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -513,9 +513,10 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
               <ol class="list-input">
                 % if about_page_editable:
                 <li class="field text" id="field-course-effort">
-                  <label for="course-effort">${_("Hours of Effort per Week")}</label>
-                  <input type="text" class="short time" id="course-effort" placeholder="HH:MM" />
-                  <span class="tip tip-inline">${_("Time spent on all course work")}</span>
+                  <label for="course-effort">${_("Programs generation indicator")}</label>
+                  <input type="text" class="short time" id="course-effort" placeholder="examples: 7 or 7:uspup" />
+                  <span class="tip">${_("Informs Programs Auto Generator how to apply generation rules to the course.")}</span>
+                  <span class="tip italic">${_("For example: `7:uspap` indicates about 7 hours duration and `uspap` special type to explicitly in/exclude course from the program.")}</span>
                 </li>
                 % endif
                 % if is_prerequisite_courses_enabled:

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -93,6 +93,7 @@ urlpatterns += patterns(
         'course_search_index_handler',
         name='course_search_index_handler'
     ),
+    url(r'^make_programs$', 'make_programs_handler', name='make-programs-handler'),
     url(r'^course/{}?$'.format(settings.COURSE_KEY_PATTERN), 'course_handler', name='course_handler'),
     url(r'^course_notifications/{}/(?P<action_state_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
         'course_notifications_handler'),

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -262,7 +262,7 @@ from openedx.core.lib.courses import course_image_url
             % endif
 
           % if get_course_about_section(request, course, "effort"):
-            <li class="important-dates-item"><span class="icon fa fa-pencil" aria-hidden="true"></span><p class="important-dates-item-title">${_("Estimated Effort")}</p><span class="important-dates-item-text effort">${get_course_about_section(request, course, "effort")}</span></li>
+            <li class="important-dates-item"><span class="icon fa fa-pencil" aria-hidden="true"></span><p class="important-dates-item-title">${_("Estimated Effort")}</p><span class="important-dates-item-text effort">${get_course_about_section(request, course, "effort").split(':')[0]}</span></li>
           % endif
 
           ##<li class="important-dates-item"><span class="icon fa fa-clock-o" aria-hidden="true"></span><p class="important-dates-item-title">${_('Course Length')}</p><span class="important-dates-item-text course-length">${_('{number} weeks').format(number=15)}</span></li>


### PR DESCRIPTION
[CALYPSO-122](https://youtrack.raccoongang.com/issue/CALYPSO-122)

Related changes:
- Programs: https://github.com/raccoongang/course-discovery/pull/1
- Theme: https://github.com/raccoongang/edx-theme/pull/432

***Description***
Adds automated Programs generation based on specified rules.
Rules are defined in Programs codebase.

****Rules explanation:****
```
PROGRAM_RULES = [
    {'name': '7/2-USPAP', 7: 2, 'uspap': False},
    # name: string - rule descriptive title;
    # 7:2 - two 7-hours courses;
    # course with program indicator `uspap` must not be included

    {'name': '7/3|3/3', 7: 3, 3: 3},
    # form programs with three 7-hours courses and three 3-hours course (no additional restrictions)

    {'name': '7/2+USPAP', 7: 2, 'uspap': True},
    ...
    # course with program indicator `uspap` must be included
]
```

****How to use****
After new course is created in order to be able extend Programs set next actions must be performed:
- in `CMS/settings/details` set `Programs generation indicator` (standard `effort`);
> examples: (where number indicates Course duration and after-colon-string is special key to control how this course should be bundled)
>  - 7
>  - 8:uspap
>  - 5:someotherspecial
- since `Programs generation indicator` is set - new `Make Programs` button is available in the controls menu of CMS/Content/Course Outline page (next to `Reindex` button);
- `Make Programs` button initiates API call to Programs service which starts Programs Regeneration procedure;
- if new Program combinations are available - new such Programs is created and feedback is shown in info message.

***Cosmetics***
Since we use course's `effort` setting a bit unusual, PR encounters small changes to the platform:
- CMS: effort field's input:
  - extended to full width;
  - help text changed;
  - subheading changed;
- LMS: `course_about` template: shrink optional `effort` info for consistency.
