### PR TITLE
DIGICOMP-13 API (issue with login via SSO)

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -690,9 +690,9 @@ def associate_by_email_if_login_api(auth_entry, backend, details, user, *args, *
     same email address in the database.  It defers to the social library's associate_by_email
     implementation, which verifies that only a single database user is associated with the email.
 
-    This association is done ONLY if the user entered the pipeline through a LOGIN API.
+    This association is done ONLY if the user entered the pipeline through a LOGIN or LOGIN API.
     """
-    if auth_entry == AUTH_ENTRY_LOGIN_API:
+    if auth_entry in [AUTH_ENTRY_LOGIN_API, AUTH_ENTRY_LOGIN]:
         association_response = associate_by_email(backend, details, user, *args, **kwargs)
         if (
             association_response and


### PR DESCRIPTION
**Description:**  
Pipeline `associate_by_email_if_login_api` - added `auth_entry` key `AUTH_ENTRY_LOGIN` into checking in order to add an association to the auth table

**Youtrack:** [DIGICOMP-13 API (issue with login via SSO)](https://youtrack.raccoongang.com/issue/DIGICOMP-13#tab=Time%20Tracking)

