### PR TITLE
[ASUSGAB-30] Requirements - update xblock_utils.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -83,7 +83,7 @@ git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd3
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.10#egg=edx-milestones==0.1.10
-git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
+git+https://github.com/edx/xblock-utils.git@v1.1.0#egg=xblock-utils==1.1.0
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5


### PR DESCRIPTION
Update xblock_utils to v.1.1.0 in requirements to enable translation tags in xblocks.

The xblock_utils update is described in the tag's message `https://github.com/edx/xblock-utils/releases/tag/v1.1.0`