### PR TITLE
Switch `ALU Skills` app to ver.0.1.1

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -102,7 +102,7 @@ git+https://github.com/Stanford-Online/xblock-in-video-quiz@release/v0.1.6#egg=i
 # alux apps
 -e git+git@github.com:aludeveloper/pcitool.git@master#egg=pcitool
 -e git+git@github.com:aludeveloper/alux_student_dashboard.git@raccoongang-develop#egg=alux_student_dashboard
--e git+git@github.com:aludeveloper/alux_skills_map.git@v0.1.0#egg=alux_skills_map
+-e git+git@github.com:aludeveloper/alux_skills_map.git@v0.1.1#egg=alux_skills_map
 -e git+git@github.com:aludeveloper/external-content-widget.git@master#egg=alu_widget
 
 # alu-xblock-adapter


### PR DESCRIPTION
**Description:** switches ALU Skills map application to v0.1.1 patch.

**Youtrack:** https://youtrack.raccoongang.com/issue/ALUE-204