### PR TITLE
[FICUS] HSEQA-19 - On the 'Certificate Preview' page, the 'Terms of Service &…

### DIFF
--- a/lms/templates/static_templates/tos_and_honor.html
+++ b/lms/templates/static_templates/tos_and_honor.html
@@ -1,0 +1,12 @@
+<%page expression_filter="h"/>
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("Terms of Service")}</%block>
+
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+        <h1>${_("Terms of Service and Honor Code")}</h1>
+        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+    </section>
+</main>


### PR DESCRIPTION
[HSEQA-19](https://youtrack.raccoongang.com/issue/HSEQA-19) - `On the 'Certificate Preview' page, the 'Terms of Service & Honor Code' link doesn't lead to the Terms of Service & Honor Code`

- New template in the `tos_and_honor.html` to `lms/templates/static_templates/`
- Need to add `"TOS_AND_HONOR": "tos_and_honor"` to the `MKTG_URL_LINK_MAP`