### PR TITLE
Update edx-proctoring version to 0.17.1

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -90,7 +90,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils==1.0.3
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.1#egg=lti_consumer-xblock==1.1.1
-git+https://github.com/edx/edx-proctoring.git@0.17.0#egg=edx-proctoring==0.17.0
+git+https://github.com/raccoongang/edx-proctoring.git@0.17.1#egg=edx-proctoring==0.17.1
 
 # Base RG modules
 git+https://github.com/raccoongang/edx-search.git@0.1.2-rg#egg=edx-search==0.1.2.1


### PR DESCRIPTION
**Issue :** Need to remove `Progress` link from submitted template.
**Solve:**
Remove block-trans from submitted.html
Create https://github.com/raccoongang/edx-proctoring/tree/0.17.1
Update github.txt requirements to git+https://github.com/raccoongang/edx-proctoring.git@0.17.1#egg=edx-proctoring==0.17.1

**Youtrack:** https://youtrack.raccoongang.com/issue/HSEQA-65

**Misc:**
- tested locally
