### PR TITLE
[CAMARA] Release re-captcha, change styles for certificate page and dinamic placeholder to MPESA

### DIFF
--- a/common/djangoapps/student/decorators.py
+++ b/common/djangoapps/student/decorators.py
@@ -1,0 +1,55 @@
+"""
+Decorators to help checking data
+"""
+import urllib
+import urllib2
+import json
+from functools import wraps
+from django.conf import settings
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+
+def check_recaptcha(view_func):
+    """
+    Check re-captcha.
+
+    Forms shoud contain the following:
+    <script src='https://www.google.com/recaptcha/api.js'></script>
+    <div class="g-recaptcha" data-sitekey="{GOOGLE_RECAPTCHA_DATA_SITE_KEY}"></div>
+    This decorator use settings.GOOGLE_RECAPTCHA_SECRET_KEY, settings.USE_GOOGLE_RECAPTCHA (True/false)
+    and Post parameter 'g-recaptcha-response' for check recaptcha and write to request next parameter:
+    'recaptcha_is_valid = True/False'
+    If re-capcha is False write messages.error.
+    For use add the decorator to view function and write check parameters 'request.recaptcha_is_valid'
+    More:
+    https://developers.google.com/recaptcha/
+    https://developers.google.com/recaptcha/docs/verify
+    :param view_func:
+    :return:
+    """
+
+    @wraps(view_func)
+    def _wrapped_view(request, *args, **kwargs):
+        request.recaptcha_is_valid = None
+        if (
+            request.method == 'POST'
+            and configuration_helpers.get_value('USE_GOOGLE_RECAPTCHA', settings.USE_GOOGLE_RECAPTCHA)
+        ):
+            # Begin re-captcha validation
+            recaptcha_response = request.POST.get('g-recaptcha-response')
+            url = 'https://www.google.com/recaptcha/api/siteverify'
+            values = {
+                'secret': settings.GOOGLE_RECAPTCHA_SECRET_KEY,
+                'response': recaptcha_response
+            }
+            data = urllib.urlencode(values)
+            req = urllib2.Request(url, data)
+            response = urllib2.urlopen(req)
+            result = json.load(response)
+            # End re-captcha validation
+            if result.get('success'):
+                request.recaptcha_is_valid = True
+
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped_view

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -3,8 +3,10 @@ import logging
 import urllib
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import cache
+from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
@@ -17,17 +19,14 @@ from django.views.decorators.http import require_http_methods
 import branding.api as branding_api
 import courseware.views.views
 import student.views
-from edxmako.shortcuts import marketing_link, render_to_response
+from edxmako.shortcuts import marketing_link, render_to_response, render_to_string
 from openedx.core.djangoapps.lang_pref.api import released_languages
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from util.cache import cache_if_anonymous
+from student.decorators import check_recaptcha
 from util.json_request import JsonResponse
+
 from .forms import ContactForm
 
-from django.core.mail import send_mail
-from edxmako.shortcuts import render_to_string
-from django.contrib.auth.models import User
-from django.middleware.csrf import CsrfViewMiddleware
 log = logging.getLogger(__name__)
 
 
@@ -313,13 +312,24 @@ def footer(request):
     else:
         return HttpResponse(status=406)
 
+
 @require_http_methods(['GET', 'POST'])
+@check_recaptcha
 def contact_form(request):
+    """
+    Render 'contact' page.
+    """
     sent_mail = False
     form = ContactForm()
+    is_use_google_recaptcha = configuration_helpers.get_value('USE_GOOGLE_RECAPTCHA', settings.USE_GOOGLE_RECAPTCHA)
+    # NOTE(AndreyLykhoman) This parameter contains 'True' as the default value.
+    #    It needs for correct working form validation when USE_GOOGLE_RECAPTCHA isn't enabled.
+    #    Also it is used in the template for show error in captcha (if we use it).
+    recaptcha_is_valid = True
     if request.method == 'POST':
+        recaptcha_is_valid = request.recaptcha_is_valid if is_use_google_recaptcha else recaptcha_is_valid
         form = ContactForm(request.POST)
-        if form.is_valid():
+        if form.is_valid() and recaptcha_is_valid:
             form_params = form.get_data
             subject, message = get_subject_and_message(
                 "emails/contact_form_email_subject.txt", "emails/contact_form_email_message.txt", form_params
@@ -336,15 +346,23 @@ def contact_form(request):
             if sent_mail:
                 form = ContactForm()
 
-    data = {'sent_mail':sent_mail, 'form': form}
-    return render_to_response('static_templates/contact.html', data )
+    data = {'sent_mail': sent_mail, 'form': form}
+    if is_use_google_recaptcha:
+        data['google_recaptcha_site_key'] = settings.GOOGLE_RECAPTCHA_DATA_SITE_KEY
+        data['recaptcha_is_valid'] = recaptcha_is_valid
+    return render_to_response('static_templates/contact.html', data)
+
 
 def get_honor_mail():
+    """
+    Return the list of staff's emails
+    """
     email_list = []
     users = User.objects.all().filter(is_staff=True)
     for user in users:
         email_list.append(user.email)
     return email_list
+
 
 def get_subject_and_message(subject_template, message_template, param_dict):
     """

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -135,7 +135,8 @@ def login_and_registration_form(request, initial_mode="login"):
             'registration_form_desc': json.loads(form_descriptions['registration']),
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
             'account_creation_allowed': configuration_helpers.get_value(
-                'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True))
+                'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)
+            ),
         },
         'login_redirect_url': redirect_to,  # This gets added to the query string of the "Sign In" button in header
         'responsive': True,
@@ -147,6 +148,9 @@ def login_and_registration_form(request, initial_mode="login"):
             settings.FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER']
         ),
     }
+
+    if configuration_helpers.get_value('USE_GOOGLE_RECAPTCHA', settings.USE_GOOGLE_RECAPTCHA):
+        context['data']['google_recaptcha_site_key'] = settings.GOOGLE_RECAPTCHA_DATA_SITE_KEY
 
     context = update_context_for_enterprise(request, context)
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1076,3 +1076,13 @@ B2C_URL = AUTH_TOKENS.get('B2C_URL', '')
 
 # number of seconds from the expiry we consider the token expired
 TOKEN_THRESHOLD = ENV_TOKENS.get('TOKEN_THRESHOLD', 600)
+
+# In google account setup a new re-captcha for the current site.
+# You will have a SECRET_KEY and a DATA_SITE_KEY. Set next settings in lms.auth.json.
+GOOGLE_RECAPTCHA_SECRET_KEY = AUTH_TOKENS.get('GOOGLE_RECAPTCHA_SECRET_KEY', '')
+GOOGLE_RECAPTCHA_DATA_SITE_KEY = AUTH_TOKENS.get('GOOGLE_RECAPTCHA_DATA_SITE_KEY', '')
+
+# Set this setting to True value if you want use re-captcha in the registration form.
+# You can set this setting in lms.env.json for all sites(microsites)
+# or set up in an admin page for each site.
+USE_GOOGLE_RECAPTCHA = ENV_TOKENS.get('USE_GOOGLE_RECAPTCHA', False)

--- a/lms/static/certificates/sass/main-ltr.scss
+++ b/lms/static/certificates/sass/main-ltr.scss
@@ -13,3 +13,39 @@ $pattern-library-path: '../../edx-pattern-library' !default;
 
 // Load the shared build
 @import 'build';
+
+
+@media print {
+  body.certificate {
+    margin-top: 1.875rem !important;
+
+    .hd-1 {
+      line-height: normal;
+      margin-bottom: 1rem;
+    }
+
+    .accomplishment-rendering {
+      .accomplishment-statement,
+      .accomplishment-signatories,
+      .accomplishment-orgs {
+        margin-bottom: 1rem;
+        margin-top: 1rem;
+      }
+
+      .accomplishment-type {
+        margin-bottom: 1rem;
+      }
+
+      .accomplishment-orgs {
+        .wrapper-organization {
+          margin-top: 1rem !important;
+          margin-bottom: 1rem !important;
+        }
+      }
+    }
+
+    &.layout-accomplishment .accomplishment-signatories .signatory {
+      width: calc(25% - 1rem);
+    }
+  }
+}

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -75,6 +75,7 @@
                     this.passwordResetSupportUrl = options.password_reset_support_link;
                     this.createAccountOption = options.account_creation_allowed;
                     this.hideAuthWarnings = options.hide_auth_warnings || false;
+                    this.googleRecaptchaSiteKey = options.google_recaptcha_site_key;
 
                 // The login view listens for 'sync' events from the reset model
                     this.resetModel = new PasswordResetModel({}, {
@@ -170,7 +171,8 @@
                             model: model,
                             thirdPartyAuth: this.thirdPartyAuth,
                             platformName: this.platformName,
-                            hideAuthWarnings: this.hideAuthWarnings
+                            hideAuthWarnings: this.hideAuthWarnings,
+                            googleRecaptchaSiteKey: this.googleRecaptchaSiteKey
                         });
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -38,6 +38,7 @@
                     this.platformName = data.platformName;
                     this.autoSubmit = data.thirdPartyAuth.autoSubmitRegForm;
                     this.hideAuthWarnings = data.hideAuthWarnings;
+                    this.googleRecaptchaSiteKey = data.googleRecaptchaSiteKey;
 
                     this.listenTo(this.model, 'sync', this.saveSuccess);
                 },
@@ -55,7 +56,8 @@
                             currentProvider: this.currentProvider,
                             providers: this.providers,
                             hasSecondaryProviders: this.hasSecondaryProviders,
-                            platformName: this.platformName
+                            platformName: this.platformName,
+                            googleRecaptchaSiteKey: this.googleRecaptchaSiteKey
                         }
                     }));
 

--- a/lms/templates/mpesa/mpesa_form.html
+++ b/lms/templates/mpesa/mpesa_form.html
@@ -3,6 +3,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.conf import settings
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <%block name="pagetitle">${_("Shopping cart")}</%block>
 
@@ -15,8 +16,10 @@ from django.conf import settings
         % for pk, pv in params.iteritems():
             <input type="hidden" name="${pk}" value="${pv}" />
         % endfor
-
-        <input type="text" name="phone" id="phone" placeholder="${_('Your phone number')}" required="required" >
+        <%
+            placeholder = configuration_helpers.get_value('PLACEHOLDER', _('Your phone number') )
+        %>
+        <input type="text" name="phone" id="phone" placeholder="${placeholder}" required="required" >
         <button id="submit" type="submit" class="button postfix discovery-submit">
             <div id="button_text">${_('Payment')}</div>
             <div aria-live="polite" aria-relevant="all">

--- a/lms/templates/mpesa/mpesa_form.html
+++ b/lms/templates/mpesa/mpesa_form.html
@@ -42,12 +42,13 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 function validate_int(myEvento) {
   var myCaja = document.getElementById("phone");
   myText = myCaja.value;
-  if ((myEvento.charCode >= 48 && myEvento.charCode <= 57) && myText.length < 12) {
-    dato = true;
-  } else {
-    dato = false;
+  charCode = myEvento.charCode
+  // The statement allows write only numbers.
+  // Firefox required 'charCode == 0' for DELETE availability.
+  if (charCode == 0  || (charCode >= 48 && charCode <= 57) && myText.length < 12){
+      return true
   }
-  return dato;
+  return false;
 }
 
 document.getElementById("phone").onkeypress = validate_int;

--- a/lms/templates/register-form.html
+++ b/lms/templates/register-form.html
@@ -264,8 +264,7 @@ from student.models import UserProfile
 </div>
 
 %if google_recaptcha_site_key:
-    <div class="g-recaptcha" data-sitekey="${google_recaptcha_site_key}"></div>
-    <script src='https://www.google.com/recaptcha/api.js'></script>
+    <div class="g-recaptcha" id="g-recaptcha" data-sitekey="${google_recaptcha_site_key}"></div>
 %endif
 
 <div class="form-actions">

--- a/lms/templates/register-form.html
+++ b/lms/templates/register-form.html
@@ -263,6 +263,11 @@ from student.models import UserProfile
   </ol>
 </div>
 
+%if google_recaptcha_site_key:
+    <div class="g-recaptcha" data-sitekey="${google_recaptcha_site_key}"></div>
+    <script src='https://www.google.com/recaptcha/api.js'></script>
+%endif
+
 <div class="form-actions">
   <button name="submit" type="submit" id="submit" class="action action-primary action-update register-button">${_('Register')} <span class="orn-plus">+</span> ${_('Create My Account')}</button>
 </div>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -19,6 +19,12 @@ import calendar
 
 <%block name="js_extra">
   <script type="text/javascript">
+    var recaptcha_widget;
+    var onloadCallback = function() {
+        recaptcha_widget = grecaptcha.render(document.getElementById('g-recaptcha'), {
+          'sitekey' : '${google_recaptcha_site_key}'
+        });
+    };
     $(function() {
 
       // adding js class for styling with accessibility in mind
@@ -70,7 +76,8 @@ import calendar
         $('.status.message.submission-error').addClass('is-shown').focus();
         $('.status.message.submission-error .message-copy').html(json.value).stop().css("display", "block");
         $(".field-error").removeClass('field-error');
-        $("[data-field='"+json.field+"']").addClass('field-error')
+        $("[data-field='"+json.field+"']").addClass('field-error');
+        grecaptcha.reset(recaptcha_widget);
       });
     })(this);
 
@@ -98,6 +105,7 @@ import calendar
       }
     }
   </script>
+  <script src='https://www.google.com/recaptcha/api.js?onload=onloadCallback'></script>
 </%block>
 
 <section class="introduction">

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -33,6 +33,9 @@
     % for template_name in ["account", "access", "form_field", "login", "register", "institution_login", "institution_register", "password_reset", "hinted_login"]:
         <script type="text/template" id="${template_name}-tpl">
             <%static:include path="student_account/${template_name}.underscore" />
+            %if template_name == "register":
+                <script src='https://www.google.com/recaptcha/api.js'></script>
+            %endif
         </script>
     % endfor
 </%block>

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -48,6 +48,10 @@
     <% } %>
 
     <%= context.fields %>
+    <% if (context.googleRecaptchaSiteKey) { %>
+        <div class="g-recaptcha" data-sitekey="<%- context.googleRecaptchaSiteKey %>"></div>
+    <% } %>
+
 
     <button type="submit" class="action action-primary action-update js-register register-button"><%- gettext("Create account") %></button>
 </form>

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -95,7 +95,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.18#egg=xblock-
 git+https://github.com/Stanford-Online/xblock-in-video-quiz@release/v0.1.6#egg=invideoquiz
 
 #Scorm xblock
--e git+https://github.com/raccoongang/edx_xblock_scorm.git#egg=edx_xblock_scorm
+-e git+https://github.com/raccoongang/edx_xblock_scorm.git@v1.0.2#egg=edx_xblock_scorm
 
 #mpesa
 -e git+https://github.com/raccoongang/mpesa_api.git@edx-ginkgo-version#egg=edx-ginkgo-version


### PR DESCRIPTION
**Description:** Release: 
 - the re-captcha
 - change styles for certificate page
 - Fix validate_int function for firefox and chrome
 - Add dinamic placeholder to MPESA payment form
 - Change version of scorm xbock

**Youtrack:** 
https://youtrack.raccoongang.com/issue/CAMARA-94
https://youtrack.raccoongang.com/issue/CAMARA-109

**Configuration instructions for re-captcha:**
In google account create SECRET_KEY and DATA_SITE_KEY. link: 
https://www.google.com/recaptcha/admin
documentation: https://developers.google.com/recaptcha/

Add new settings to lms.auth.json with values from google's account:
GOOGLE_RECAPTCHA_SECRET_KEY = #SECRET_KEY
GOOGLE_RECAPTCHA_DATA_SITE_KEY = #DATA_SITE_KEY

Also, you can set to lms.env.json "USE_GOOGLE_RECAPTCHA": true. It means that re-captcha will be in each microsite's registration form.

If you want to use re-captcha only one microsite you should set "USE_GOOGLE_RECAPTCHA": true in site configuration in the admin page.
