### PR TITLE
FM-33 Sign-in page: Change the registration button text and move the …

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1702,25 +1702,25 @@ def create_account_with_params(request, params):
         settings.FEATURES.get("ENFORCE_PASSWORD_POLICY", False) and
         not do_external_auth
     )
+    registration_fields = configuration_helpers.get_value('REGISTRATION_EXTRA_FIELDS', getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {}))
+    # No needed so far
     # Can't have terms of service for certain SHIB users, like at Stanford
-    registration_fields = getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {})
-    tos_required = (
-        registration_fields.get('terms_of_service') != 'hidden' or
-        registration_fields.get('honor_code') != 'hidden'
-    ) and (
-        not settings.FEATURES.get("AUTH_USE_SHIB") or
-        not settings.FEATURES.get("SHIB_DISABLE_TOS") or
-        not do_external_auth or
-        not eamap.external_domain.startswith(openedx.core.djangoapps.external_auth.views.SHIBBOLETH_DOMAIN_PREFIX)
-    )
-
+    # tos_required = (
+    #     registration_fields.get('terms_of_service') != 'hidden' or
+    #     registration_fields.get('honor_code') != 'hidden'
+    # ) and (
+    #     not settings.FEATURES.get("AUTH_USE_SHIB") or
+    #     not settings.FEATURES.get("SHIB_DISABLE_TOS") or
+    #     not do_external_auth or
+    #     not eamap.external_domain.startswith(openedx.core.djangoapps.external_auth.views.SHIBBOLETH_DOMAIN_PREFIX)
+    # )
     form = AccountCreationForm(
         data=params,
         extra_fields=extra_fields,
         extended_profile_fields=extended_profile_fields,
         enforce_username_neq_password=True,
         enforce_password_policy=enforce_password_policy,
-        tos_required=tos_required,
+        tos_required=registration_fields.get('terms_of_service') != 'hidden',
     )
     custom_form = get_registration_extension_form(data=params)
 

--- a/lms/templates/register-form.html
+++ b/lms/templates/register-form.html
@@ -236,13 +236,15 @@ from student.models import UserProfile
   <ol class="list-input">
     <li class="field-group">
 
-      % if has_extauth_info is UNDEFINED or ask_for_tos :
-      <div class="field required checkbox" id="field-tos">
-        <input id="tos-yes" type="checkbox" name="terms_of_service" value="true" required aria-required="true" />
-        <label for="tos-yes">${_('I agree to the {link_start}Terms of Service{link_end}').format(
-          link_start='<a href="{url}" class="new-vp" tabindex="-1">'.format(url=marketing_link('TOS')),
-          link_end='</a>')}</label>
-      </div>
+      % if REGISTRATION_EXTRA_FIELDS['terms_of_service'] != 'hidden':
+          % if has_extauth_info is UNDEFINED or ask_for_tos :
+          <div class="field ${REGISTRATION_EXTRA_FIELDS['terms_of_service']} checkbox" id="field-tos">
+            <input id="tos-yes" type="checkbox" name="terms_of_service" value="true" required aria-required="true" />
+            <label for="tos-yes">${_('I agree to the {link_start}Terms of Service{link_end}').format(
+              link_start='<a href="{url}" class="new-vp" tabindex="-1">'.format(url=marketing_link('TOS')),
+              link_end='</a>')}</label>
+          </div>
+          % endif
       % endif
 
       % if REGISTRATION_EXTRA_FIELDS['honor_code'] != 'hidden':


### PR DESCRIPTION
[FM-33](
https://youtrack.raccoongang.com/issue/FM-33) - `Sign-in page: Change the registration button text and move the text`
  - Made the `terms_of_service` registration field adjustable from the admin Site Configuration page