### PR TITLE
[FICUS]SQLI-13 The 'course start' date is displayed incorrectly on the main …

### DIFF
--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -22,7 +22,7 @@ from django.core.urlresolvers import reverse
       <%
       if course.start is not None:
           course_date_string = course.start.strftime('%Y-%m-%dT%H:%M:%S%z')
-          course_date_string_format = course.start.strftime('%d %b. %Y')
+          course_date_string_format = course.start.strftime('%B %-d, %Y')
       else:
           course_date_string = ''
       %>


### PR DESCRIPTION
[SQLI-13](https://youtrack.raccoongang.com/issue/SQLI-13) - `The 'course start' date is displayed incorrectly on the main page when a user isn't logged in.`

- changed format for displaying course start date at the main page for not logged in user