### PR TITLE
[FABB] add path to raccoon django-wiki repos

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@
 
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.9#egg=django-wiki==0.0.9
+git+https://github.com/raccoongang/django-wiki.git@v0.0.9.2#egg=django-wiki==0.0.9.2
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
**Description:** fix anonymous ip not logged when merge different version  of wiki article.
Change old tag to tag with fix.(`0.0.9` to `0.0.9.2`)

**Youtrack:** https://youtrack.raccoongang.com/issue/FABB-28

