### PR TITLE
[ASUYTP] Asu ginkgo stage fix boolean fields

### DIFF
--- a/lms/djangoapps/ytp_api/serializers.py
+++ b/lms/djangoapps/ytp_api/serializers.py
@@ -21,9 +21,7 @@ class UserSerializer(HyperlinkedModelSerializer):
 
     class Meta(object):
         model = User
-        # NOTE(AndreyLykhoman): Added 'is_active' field to 'read_only_fields' for disable changing this field. It was
-        #  needed to disable deactivating user when we create a new user without is_active param.
-        read_only_fields = ('password', 'username', 'is_active')
+        read_only_fields = ('password', 'username')
 
     def update(self, instance, data):
         """


### PR DESCRIPTION
**Description:** Fix problem with Changing User and UserProfile fields to default to None value when we create or update.
Changed type of request.data to Dict and add function to checking required boolean fields('is_active', 'allow_certificate') when the user is created.

**Youtrack:** https://youtrack.raccoongang.com/issue/ASUYT-137

