### PR TITLE
[ALUE] Register `pcitool` application to cms

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1038,8 +1038,9 @@ INSTALLED_APPS = (
     # Waffle related utilities
     'openedx.core.djangoapps.waffle_utils',
 
-    # ALUx Staff HQ application
+    # ALUx Staff HQ applications
     'alux_skills_map',
+    'pcitool',
 )
 
 


### PR DESCRIPTION
Fix for deployment issue:

```
"ERRORS:", "alux_skills_map.PeerGroupAssessment.peer_group: (fields.E300) 
Field defines a relation with model 'PciPeerGroups', which is either not installed, or is abstract."]
```