### PR TITLE
[HAWTHORN] ACT-23 If a staff merges wiki revisions, 'by anonymous (IP not logged…

### DIFF
--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -62,7 +62,7 @@
 
 # Third-party:
 -e git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/raccoongang/django-wiki.git@v0.0.18-rg#egg=django-wiki
+-e git+https://github.com/raccoongang/django-wiki.git@v0.0.18.1#egg=django-wiki
 -e git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev


### PR DESCRIPTION
[ACT-23](
https://youtrack.raccoongang.com/issue/ACT-23) - `If a staff merges wiki revisions, 'by anonymous (IP not logged)' is displayed for the merged revision.`

- changed django-wiki version from v0.0.18 to v0.0.18.1 - revision merge fix (https://github.com/raccoongang/django-wiki/commit/c8d628abd0d41b7e4a49d4fbcb636877c04587a7)

# Note
There is no tag `v0.0.18-rg` in raccoongang/django-wiki repository