### PR TITLE
Flane 132/Open ed`x catalogue email service

### DIFF
--- a/lms/djangoapps/bulk_email/migrations/0006_auto_20190214_1518.py
+++ b/lms/djangoapps/bulk_email/migrations/0006_auto_20190214_1518.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bulk_email', '0005_move_target_data'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='courseemail',
+            name='from_addr',
+            field=models.CharField(default='127.0.0.1:8000', max_length=255, null=True),
+        ),
+    ]

--- a/lms/djangoapps/dashboard/admin.py
+++ b/lms/djangoapps/dashboard/admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from dashboard.models import EmailsAdressMailing
+
+@admin.register(EmailsAdressMailing)
+class EmailsAdressMailingAdmin(admin.ModelAdmin):
+    fields = ('email', 'comment', 'active')
+    list_display = ('email', 'comment', 'active')
+    list_filter = ('active',)
+    search_fields = ['email']

--- a/lms/djangoapps/dashboard/models.py
+++ b/lms/djangoapps/dashboard/models.py
@@ -2,6 +2,7 @@
 
 import mongoengine
 from xmodule.modulestore.mongoengine_fields import CourseKeyField
+from django.db import models
 
 
 class CourseImportLog(mongoengine.Document):
@@ -15,3 +16,9 @@ class CourseImportLog(mongoengine.Document):
     created = mongoengine.DateTimeField()
     meta = {'indexes': ['course_id', 'created'],
             'allow_inheritance': False}
+
+
+class EmailsAdressMailing(models.Model):
+    email = models.EmailField(max_length=254)
+    active = models.BooleanField()
+    comment = models.TextField(blank=True)

--- a/lms/djangoapps/dashboard/tasks.py
+++ b/lms/djangoapps/dashboard/tasks.py
@@ -1,0 +1,99 @@
+"""
+This file contains celery tasks sysdashboard
+"""
+import logging
+import time
+import StringIO
+import xlwt
+
+from celery import task
+from django.core.cache import cache
+from django.conf import settings
+from django.core.mail import EmailMessage, get_connection
+from django.utils.translation import ugettext as _
+
+from student.roles import CourseStaffRole, CourseInstructorRole
+from xmodule.modulestore.django import modulestore
+from .models import EmailsAdressMailing
+
+
+@task(name='mass_sending_report')
+def mass_sending_report():
+    connection = get_connection()
+    xls_file = get_courses_xls()
+    email_list = []
+    for email in EmailsAdressMailing.objects.all():
+        if email.active:
+            email_message = EmailMessage('Catalogue Email Service', 'Report for courses', settings.EMAIL_FROM, [email.email],)
+            email_message.attach('Courses_report.xls', xls_file.getvalue(), 'application/vnd.ms-excel')
+            email_list.append(email_message)
+    connection.send_messages(tuple(email_list))
+    
+@task()
+def send_report_email(request, email_adress):
+    xls_file = get_courses_xls()
+    email_message = EmailMessage('Catalogue Email Service', 'Report for courses', settings.EMAIL_FROM, [email_adress],)
+    email_message.attach('Courses_{0}.xls'.format(request.META['SERVER_NAME']), xls_file.getvalue(), 'application/vnd.ms-excel')
+    email_message.send()
+
+@task()
+def get_courses_xls():
+    """
+    Getting course data and return xls file
+    """
+    data = []
+    roles = [CourseInstructorRole, CourseStaffRole, ]
+    def_ms = modulestore()
+    for course in def_ms.get_courses():
+        if course.enrollment_end:
+            enroll_end_date = course.enrollment_end
+            enroll_end_date = enroll_end_date.strftime("%m/%d/%Y")
+        else:
+            enroll_end_date = ''
+        if course.end:
+            end_date = course.end
+            end_date = end_date.strftime("%m/%d/%Y")
+        else:
+            end_date = ''
+        datum = [settings.LMS_ROOT_URL + "/courses/" + str(course.id), course.id.run, course.display_name, 
+                enroll_end_date, end_date, ]
+        data.append(datum)
+
+    header = [('Course URL', 16000),
+              ('Course Run ID', 5000),
+              (_('Course name'), 10000),
+              (_('Enrollment end date'), 5000),
+              (_('Course end date'), 5000)]
+    return return_xls(header, data)
+
+def return_xls(header, data):
+    """
+    Xls file generation
+    """
+    xls_file = StringIO.StringIO()
+    wb = xlwt.Workbook()
+    ws = wb.add_sheet('Courses')
+
+    style = xlwt.XFStyle()
+    pattern = xlwt.Pattern()
+    pattern.pattern = xlwt.Pattern.SOLID_PATTERN
+    pattern.pattern_fore_colour = xlwt.Style.colour_map['gray25']
+    style.pattern = pattern
+
+
+
+    row_num = 0
+    ws.header_str = 'what you prefer' 
+    for col_num in range(len(header)):
+        ws.write(0, col_num, header[col_num][0], style)
+        ws.col(col_num).width = header[col_num][1]
+
+    for row in data:
+        row_num += 1
+        for col_num in range(len(row)):
+            ws.write(row_num, col_num, row[col_num])
+
+    ws.set_panes_frozen(True)
+    ws.set_horz_split_pos(1)
+    wb.save(xls_file)
+    return xls_file

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -131,8 +131,19 @@ if OPENEDX_LEARNERS_GLOBAL_ANALYTICS_ENABLE and OPENEDX_LEARNERS_GLOBAL_ANALYTIC
         'collect_stats': {
             'task': 'openedx.core.djangoapps.edx_global_analytics.tasks.collect_stats',
             'schedule': crontab(hour=0, minute=random.randint(1, 59)),
-        }
+        },
     })
+
+    
+CELERYBEAT_SCHEDULE.update({
+    # send an email with a report on the courses to the mail 
+    # specified in the model EmailsAdressMailing 
+    # every Monday morning at 11:30 A.M
+    "mass-sending-report": {
+        "task": "mass_sending_report",
+        "schedule": crontab(hour=11, minute=30, day_of_week=1),
+    },
+})
 
 # STATIC_ROOT specifies the directory where static files are
 # collected

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -168,7 +168,7 @@ textarea {
 	  <label for="email">
 		${_('Email adress')}:
 	  </label>
-	  <input type="text" name="email" style="width:60%" />
+	  <input type="email" name="email" style="width:60%" />
 	</li>
   </ul>
   <div class="form-actions">
@@ -178,6 +178,11 @@ textarea {
 	<button name="action" value="get_courses_xls">Download courses list</button>
 
 </form>
+<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
+<script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.13.1/jquery.validate.min.js"></script>
+<script>
+	$('#action').validate();
+</script>
 <hr style="width:40%" />
 %endif
 

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -161,6 +161,22 @@ textarea {
   <div class="form-actions">
 	<button type="submit" name="action" value="del_course">${_('Delete course from site')}</button>
   </div>
+
+	<hr />
+  <ul class="list-input">
+	<li class="field text">
+	  <label for="email">
+		${_('Email adress')}:
+	  </label>
+	  <input type="text" name="email" style="width:60%" />
+	</li>
+  </ul>
+  <div class="form-actions">
+	<button type="submit" name="action" value="send_courses_xls">Send courses list</button>
+	</div>
+	<hr />
+	<button name="action" value="get_courses_xls">Download courses list</button>
+
 </form>
 <hr style="width:40%" />
 %endif

--- a/pavelib/servers.py
+++ b/pavelib/servers.py
@@ -157,7 +157,7 @@ def celery(options):
     """
     Runs Celery workers.
     """
-    settings = getattr(options, 'settings', 'dev_with_worker')
+    settings = getattr(options, 'settings', 'devstack_with_worker')
     run_process(django_cmd('lms', settings, 'celery', 'worker', '--beat', '--loglevel=INFO', '--pythonpath=.'))
 
 


### PR DESCRIPTION
[FLANE-132](https://youtrack.raccoongang.com/issue/FLANE-132) Open edX Catalogue Email Service

AC:
Users receive a report on email in XLS format
Email Subject: Catalogue Email Service
Admin can set users emails who can receive the report (in django admin ) + the Active checkbox
Weekly auto reports (for example on Monday)
On Sysadmin Dashboard:
Sysadmin can send the report manually from the Sysadmin Dashboard>Courses
Sysadmin can export the report from LMS
The report should include the next data:

1. Course Run ID (the last 7 digits of the URL)
2. Course URL
3. Course name
4. Enrollment end date
5. Course end date