### PR TITLE
[OLGA] Fixed getting statistics by dates

### DIFF
--- a/openedx/core/djangoapps/edx_global_analytics/tests/test_utils.py
+++ b/openedx/core/djangoapps/edx_global_analytics/tests/test_utils.py
@@ -204,7 +204,7 @@ class TestGetStatsDailyRegistered(TestCase):
         User.objects.create(username='test4', password='test4', email='test4@example.com', date_joined='2018-01-01')
         second_students_part, _ = get_registered_students_daily('test-token')
 
-        self.assertEqual(len(second_students_part), 1)
+        self.assertEqual(len(second_students_part), 2)
         self.assertEqual(second_students_part['2018-01-01'], 1)
 
 
@@ -256,7 +256,7 @@ class TestGetStatsDailyCertificates(TestCase):
         cert4.save()
         second_certificates_part, _ = get_generated_certificates_daily('test-token')
 
-        self.assertEqual(len(second_certificates_part), 1)
+        self.assertEqual(len(second_certificates_part), 2)
         self.assertEqual(second_certificates_part['2018-01-01'], 1)
 
 

--- a/openedx/core/djangoapps/edx_global_analytics/utils/utilities.py
+++ b/openedx/core/djangoapps/edx_global_analytics/utils/utilities.py
@@ -150,7 +150,7 @@ def get_registered_students_daily(token):
     :return: Dictionary where the keys is a dates and the values is the counts.
     """
     last_date = get_last_analytics_sent_date('registered_students', token)
-    queryset = User.objects.filter(date_joined__gt=last_date)
+    queryset = User.objects.filter(date_joined__gte=last_date)
 
     registered_users = queryset.extra(select={'date': 'date( date_joined )'}).values('date').annotate(
         count=Count('id'), datetime=Max('date_joined')
@@ -169,7 +169,7 @@ def get_generated_certificates_daily(token):
     :return: Dictionary where the keys is a dates and the values is the counts.
     """
     last_date = get_last_analytics_sent_date('generated_certificates', token)
-    queryset = GeneratedCertificate.objects.filter(created_date__gt=last_date)
+    queryset = GeneratedCertificate.objects.filter(created_date__gte=last_date)
 
     generated_certificates = queryset.extra(select={'date': 'date( created_date )'}).values('date').annotate(
         count=Count('id'), datetime=Max('created_date')
@@ -189,7 +189,7 @@ def get_enthusiastic_students_daily(token):
     """
     last_date = get_last_analytics_sent_date('enthusiastic_students', token)
     last_sections_ids = get_all_courses_last_sections_ids()
-    queryset = StudentModule.objects.filter(created__gt=last_date, module_state_key__in=last_sections_ids)
+    queryset = StudentModule.objects.filter(created__gte=last_date, module_state_key__in=last_sections_ids)
 
     enthusiastic_students = queryset.extra(select={'date': 'date( modified )'}).values('date').annotate(
         count=Count('student_id', datetime=Max('created'))


### PR DESCRIPTION
**Description:**
Changed filtering query's condition for getting statistics with last date from cache.
Fix tests.
**Youtrack:**
https://youtrack.raccoongang.com/issue/OLGA-65
