### PR TITLE
CLOUDSOCIETY-48 400 error: hasn't enrolled (when I enrolled in this course (but it was hack))

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -155,6 +155,12 @@ from openedx.core.lib.courses import course_image_url
         ## so that they can register and become a real user that can enroll.
         % elif not is_shib_course and not can_enroll:
           <span class="register disabled">${_("Enrollment is Closed")}</span>
+
+            <!-- Customization for loging in -->
+            <a href="${course_target}" class="register disabled">
+              ${ "View course" | h}
+            </a>
+            <!-- End customization -->
         %elif can_add_course_to_cart:
           <%
           if user.is_authenticated():


### PR DESCRIPTION
[CLOUDSOCIETY-48](https://youtrack.raccoongang.com/issue/CLOUDSOCIETY-48) - `400 error: hasn't enrolled (when I enrolled in this course (but it was hack))`
- Do not send enrollment request when clicking by the button "View course", go to the Course Info instead