### PR TITLE
CLOUDSOCIETY-85 Open edX Catalogue Email Service

### DIFF
--- a/lms/djangoapps/dashboard/admin.py
+++ b/lms/djangoapps/dashboard/admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from dashboard.models import EmailsAddressMailing
+
+@admin.register(EmailsAddressMailing)
+class EmailsAddressMailingAdmin(admin.ModelAdmin):
+    fields = ('email', 'comment', 'active')
+    list_display = ('email', 'comment', 'active')
+    list_filter = ('active',)
+    search_fields = ['email']

--- a/lms/djangoapps/dashboard/migrations/0001_initial.py
+++ b/lms/djangoapps/dashboard/migrations/0001_initial.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EmailsAddressMailing',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('email', models.EmailField()),
+                ('active', models.BooleanField()),
+                ('comment', models.TextField(blank=True)),
+            ],
+        ),
+    ]

--- a/lms/djangoapps/dashboard/models.py
+++ b/lms/djangoapps/dashboard/models.py
@@ -1,6 +1,7 @@
 """Models for dashboard application"""
 
 import mongoengine
+from django.db import models
 from xmodule.modulestore.mongoengine_fields import CourseKeyField
 
 
@@ -15,3 +16,9 @@ class CourseImportLog(mongoengine.Document):
     created = mongoengine.DateTimeField()
     meta = {'indexes': ['course_id', 'created'],
             'allow_inheritance': False}
+
+
+class EmailsAddressMailing(models.Model):
+    email = models.EmailField()
+    active = models.BooleanField()
+    comment = models.TextField(blank=True)

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -32,11 +32,12 @@ from path import Path as path
 from courseware.courses import get_course_by_id
 import dashboard.git_import as git_import
 from dashboard.git_import import GitImportError
-from student.roles import CourseStaffRole, CourseInstructorRole
 from dashboard.models import CourseImportLog
+from dashboard.tasks import get_courses_xls, send_report_email
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 from openedx.core.djangoapps.external_auth.views import generate_password
 from student.models import CourseEnrollment, UserProfile, Registration
+from student.roles import CourseStaffRole, CourseInstructorRole
 import track.views
 from xmodule.modulestore.django import modulestore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
@@ -497,6 +498,18 @@ class Courses(SysadminDashboardView):
                 self.msg += \
                     u"<font color='red'>{0} {1} = {2} ({3})</font>".format(
                         _('Deleted'), course.location.to_deprecated_string(), course.id.to_deprecated_string(), course.display_name)
+
+        elif action == 'get_courses_xls':
+            xls_file = get_courses_xls.delay()
+            response = HttpResponse(xls_file.result.getvalue(), content_type='application/vnd.ms-excel')
+            response['Content-Disposition'] = 'attachment; filename=Courses_{0}.xls'.format(request.META['SERVER_NAME'])
+            return response
+        
+        elif action == 'send_courses_xls':
+            email_address = request.POST.get('email')
+            if email_address:
+                server_name = request.META['SERVER_NAME']
+                send_report_email.delay(server_name, email_address)
 
         context = {
             'datatable': self.make_datatable(),

--- a/lms/djangoapps/dashboard/tasks.py
+++ b/lms/djangoapps/dashboard/tasks.py
@@ -1,0 +1,103 @@
+"""
+This file contains celery tasks sysdashboard
+"""
+import logging
+import time
+import StringIO
+
+import xlwt
+from celery import task
+from django.core.cache import cache
+from django.conf import settings
+from django.core.mail import EmailMessage, get_connection
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+
+from student.roles import CourseStaffRole, CourseInstructorRole
+from xmodule.modulestore.django import modulestore
+
+from .models import EmailsAddressMailing
+
+logger = logging.getLogger(__name__)
+
+@task(name='mass_sending_report')
+def mass_sending_report():
+    connection = get_connection()
+    xls_file = get_courses_xls()
+    email_list = []
+    for email in EmailsAddressMailing.objects.filter(active=True):
+        email_message = EmailMessage('Catalogue Email Service', 'Hi all,\nThe list of courses is in the attachment.', settings.DEFAULT_FROM_EMAIL, [email.email],)
+        email_message.attach('Courses_report.xls', xls_file.getvalue(), 'application/vnd.ms-excel')
+        email_list.append(email_message)
+    if email_list:
+        connection.send_messages(tuple(email_list))
+        logger.info('mass_sending_report: {} emails sent successfully.'.format(len(email_list)))
+    
+@task()
+def send_report_email(server_name, email_address):
+    xls_file = get_courses_xls()
+    email_message = EmailMessage('Catalogue Email Service', 'Hi all,\nThe list of courses is in the attachment.', settings.DEFAULT_FROM_EMAIL, [email_address],)
+    email_message.attach('Courses_{0}.xls'.format(server_name), xls_file.getvalue(), 'application/vnd.ms-excel')
+    email_message.send()
+    logger.info('send_report_email: email sent successfully')
+
+@task()
+def get_courses_xls():
+    """
+    Getting course data and return xls file
+    _____________________________________________________________________________________
+    | Course URL | Course Run ID  | Course name | Enrollment end date | Course end date |
+    """
+    data = []
+    module_store = modulestore()
+    for course in module_store.get_courses():
+        enrollment_start_date = course.enrollment_start.strftime("%m/%d/%Y") if course.enrollment_start else ''
+        course_start_date = course.start.strftime("%m/%d/%Y") if course.start else ''
+        enroll_end_date = course.enrollment_end.strftime("%m/%d/%Y") if course.enrollment_end else ''
+        end_date = course.end.strftime("%m/%d/%Y") if course.end else ''
+        course_url = '{}{}'.format(
+            settings.LMS_ROOT_URL,
+            reverse('course_root', kwargs={'course_id': course.id})
+        )
+        datum = [course_url, course.id.run, course.display_name, course_start_date,
+                end_date, enrollment_start_date, enroll_end_date,]
+        data.append(datum)
+
+    header = [(_('Course URL'), 16000),
+              (_('Course Run ID'), 5000),
+              (_('Course name'), 10000),
+              (_('Course start date'), 5000),
+              (_('Course end date'), 5000),
+              (_('Enrollment start date'), 5000),
+              (_('Enrollment end date'), 5000)]
+              
+    return return_xls(header, data)
+
+def return_xls(header, data):
+    """
+    Xls file generation
+    """
+    xls_file = StringIO.StringIO()
+    wb = xlwt.Workbook()
+    ws = wb.add_sheet('Courses')
+
+    style = xlwt.XFStyle()
+    pattern = xlwt.Pattern()
+    pattern.pattern = xlwt.Pattern.SOLID_PATTERN
+    pattern.pattern_fore_colour = xlwt.Style.colour_map['gray25']
+    style.pattern = pattern
+
+    row_num = 0
+    for col_num in range(len(header)):
+        ws.write(row_num, col_num, header[col_num][0], style)
+        ws.col(col_num).width = header[col_num][1]
+
+    for row in data:
+        row_num += 1
+        for col_num in range(len(row)):
+            ws.write(row_num, col_num, row[col_num])
+
+    ws.set_panes_frozen(True)
+    ws.set_horz_split_pos(1)
+    wb.save(xls_file)
+    return xls_file

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -6,19 +6,23 @@ import os
 import re
 import shutil
 import unittest
+import mock
+
 from uuid import uuid4
 from util.date_utils import get_time_display, DEFAULT_DATE_TIME_FORMAT
 from nose.plugins.attrib import attr
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.core.mail import EmailMessage, get_connection
 from django.test.client import Client
 from django.test.utils import override_settings
 from django.utils.timezone import utc as UTC
 import mongoengine
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
-from dashboard.models import CourseImportLog
+from dashboard.tasks import return_xls, get_courses_xls, mass_sending_report
+from dashboard.models import CourseImportLog, EmailsAddressMailing
 from dashboard.git_import import GitImportErrorNoDir
 from datetime import datetime
 from student.roles import CourseStaffRole, GlobalStaff
@@ -26,6 +30,8 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
+from xmodule.modulestore.tests.factories import CourseFactory, LibraryFactory
+from xmodule.modulestore import ModuleStoreEnum
 
 
 TEST_MONGODB_LOG = {
@@ -38,6 +44,54 @@ TEST_MONGODB_LOG = {
 
 FEATURES_WITH_SSL_AUTH = settings.FEATURES.copy()
 FEATURES_WITH_SSL_AUTH['AUTH_USE_CERTIFICATES'] = True
+
+
+class TestReportSending(SharedModuleStoreTestCase):
+    """
+    Check the functionality of sending reports.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(TestReportSending, cls).setUpClass()
+        cls.store = modulestore()
+        cls.first_lib = LibraryFactory.create(
+            org='test', library='lib1', display_name='run1', default_store=ModuleStoreEnum.Type.split
+        )
+        cls.second_lib = LibraryFactory.create(
+            org='test', library='lib2', display_name='run2', default_store=ModuleStoreEnum.Type.split
+        )
+
+        cls.first_course = CourseFactory.create(
+            org='test', course='course1', display_name='run1'
+        )
+        cls.second_course = CourseFactory.create(
+            org='test', course='course2', display_name='run1'
+        )
+        EmailsAddressMailing.objects.create(email='mail+1@exemple.com', active=True, comment='comment')
+        EmailsAddressMailing.objects.create(email='mail+2@exemple.com', active=True, comment='comment')
+        EmailsAddressMailing.objects.create(email='mail+3@exemple.com', active=False, comment='comment')
+
+    def mock_return_xls(header, data):
+        return data
+
+    @mock.patch('dashboard.tasks.return_xls', side_effect=mock_return_xls)
+    def test_get_courses_xls(self, return_xls):
+        """Assert the count of lines in the file with the count of courses."""
+        data = get_courses_xls()
+        count_courses = 2
+        self.assertEqual(count_courses, len(data))
+
+    @mock.patch('dashboard.tasks.EmailMessage')
+    @mock.patch('dashboard.tasks.get_connection')
+    @mock.patch('dashboard.tasks.settings')
+    @mock.patch('dashboard.tasks.return_xls')
+    @override_settings(EMAIL_FROM='mail@exemple.com')
+    def test_mass_sending_report(self, return_xls, settings, get_connection, EmailMessage):
+        """Assert count of active emails in the database with the count of emails to send."""
+        mass_sending_report()
+        email_list = get_connection().send_messages.call_args
+        count_emails = EmailsAddressMailing.objects.filter(active=True).count()
+        self.assertEqual(count_emails, len(email_list))
 
 
 class SysadminBaseTestCase(SharedModuleStoreTestCase):

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -9,6 +9,11 @@ from django.utils.translation import ugettext as _
   <%static:css group='style-course'/>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.axislabels.js')}"></script>
+	<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
+	<script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.13.1/jquery.validate.min.js"></script>
+	<script>
+		$('#action').validate();
+	</script>
 </%block>
 
 <style type="text/css">
@@ -161,6 +166,22 @@ textarea {
   <div class="form-actions">
 	<button type="submit" name="action" value="del_course">${_('Delete course from site')}</button>
   </div>
+
+	<hr />
+  <ul class="list-input">
+	<li class="field text">
+	  <label for="email">
+		${_('Email address')}:
+	  </label>
+	  <input type="email" name="email" style="width:60%" />
+	</li>
+  </ul>
+  <div class="form-actions">
+	<button type="submit" name="action" value="send_courses_xls">Send courses list</button>
+	</div>
+	<hr />
+	<button name="action" value="get_courses_xls">Download courses list</button>
+
 </form>
 <hr style="width:40%" />
 %endif

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -200,3 +200,6 @@ py2neo==3.1.2
 -r coverage.txt
 
 pyDes==2.0.1
+
+# Write to xls
+xlwt==1.2.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -101,3 +101,6 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.15#egg=xblock-
 -e git+https://github.com/raccoongang/edx-search.git@0.1.2-rg#egg=edx-search
 # Raccoongang rg_instructor_analytics
 -e git+https://github.com/raccoongang/rg_instructor_analytics@release-0.2.3#egg=rg_instructor_analytics
+
+# RaccoonGang
+git+https://github.com/raccoongang/django-oidc.git@sso-microsites#egg=django-oidc


### PR DESCRIPTION
[CLOUDSOCIETY-85](https://youtrack.raccoongang.com/issue/CLOUDSOCIETY-85) Open edX Catalogue Email Service
AC:
Users receive a report on email in XLS format
Email Subject: Catalogue Email Service
Admin can set users emails who can receive the report (in django admin ) + the Active checkbox
Weekly auto reports (for example on Monday)
On Sysadmin Dashboard:
Sysadmin can send the report manually from the Sysadmin Dashboard>Courses
Sysadmin can export the report from LMS
The report should include the next data:
1. Course name
2. Course Run ID (the last 7 digits of the URL)
3. Course URL
4. Enrollment end date
5. Course end date
6. Enrollment start date
7. Course start date

