### PR TITLE
[HBI] Fix ImportError: No module named tinymce

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -351,3 +351,5 @@ xblock==1.2.1
 xmltodict==0.11.0
 zendesk==1.1.1
 zope.interface==4.5.0
+django-tinymce==2.8.0
+django-hvad==1.8.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -332,3 +332,5 @@ xblock==1.2.1
 xmltodict==0.11.0         # via moto
 zendesk==1.1.1
 zope.interface==4.5.0     # via twisted
+django-tinymce==2.8.0
+django-hvad==1.8.0


### PR DESCRIPTION
https://youtrack.raccoongang.com/issue/HBI-193
при добавлении нового app 'Info pages' забыли добавить новые зависимости в development.txt и testing.txt
django-tinymce
django-hvad