### PR TITLE
FLANE-176 Course overview is missing on FLL

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -988,7 +988,7 @@ def settings_handler(request, course_key_string):
                 settings.FEATURES.get('ENABLE_EXTENDED_COURSE_DETAILS', False)
             )
 
-            about_page_editable = not marketing_site_enabled
+            about_page_editable = True  # The dirty hack in order to make all About page fields editable
             enrollment_end_editable = GlobalStaff().has_user(request.user) or not marketing_site_enabled
             short_description_editable = configuration_helpers.get_value_for_org(
                 course_module.location.org,


### PR DESCRIPTION
[FLANE-176](
https://youtrack.raccoongang.com/issue/FLANE-176) - `Course overview is missing on FLL`
- made all Course About fields editable from the Studio course settings