### PR TITLE
[T-37] 500 if a user opens the Log In page in CMS.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1273,6 +1273,7 @@ OPTIONAL_APPS = (
     ('integrated_channels.integrated_channel', None),
     ('integrated_channels.degreed', None),
     ('integrated_channels.sap_success_factors', None),
+    ('tedix_ro', None)
 )
 
 

--- a/themes/red-theme/cms/templates/login.html
+++ b/themes/red-theme/cms/templates/login.html
@@ -6,6 +6,7 @@
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 <%block name="title">${_("Sign In")}</%block>
 <%block name="bodyclass">not-signedin view-signin</%block>


### PR DESCRIPTION
[T-37](https://youtrack.raccoongang.com/issue/T-37) - `500 if a user opens the Log In page in CMS.`
- added tedix_ro to the OPTIONAL_APPS
- fixed login.html in the red-theme