### PR TITLE
[CommonBugs] Implement validation article title to avoid creating numeric slug CB-101

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@
 
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.9#egg=django-wiki==0.0.9
+git+https://github.com/raccoongang/django-wiki.git@v0.0.9.1#egg=django-wiki==v0.0.9.1
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
**Description:** set django-wiki raccoongang fork instead of edx, cause in first one already was implemented solution for validation non-numeric slugs

**Youtrack:** https://youtrack.raccoongang.com/issue/CB-101

**Testing instructions:**

full instruction in youtrack task

**Reviewers:**
- [ ] @oksana-slu 
- [ ] @idegtiarov 

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
