### PR TITLE
T-46 On the CMS login page, removed Sign Up link.

### DIFF
--- a/themes/red-theme/cms/templates/login.html
+++ b/themes/red-theme/cms/templates/login.html
@@ -16,7 +16,6 @@ from openedx.core.djangolib.js_utils import js_escaped_string
   <section class="content">
     <header>
       <h1 class="title title-1">${_("Sign In to {studio_name}").format(studio_name=settings.STUDIO_NAME)}</h1>
-      <a href="${reverse('signup')}" class="action action-signin">${_("Don't have a {studio_name} Account? Sign up!").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
     </header>
     <!-- Login Page override for red-theme. -->
     <article class="content-primary" role="main">


### PR DESCRIPTION
[T-46](https://youtrack.raccoongang.com/issue/T-46) On the CMS login page, the Sign Up link is displayed.