### PR TITLE
LLTV-51 On the Certificate Preview page, if a user clicks the ToS lin…

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2194,6 +2194,7 @@ MKTG_URL_LINK_MAP = {
     'ROOT': 'root',
     'TOS': 'tos',
     'HONOR': 'honor',  # If your site does not have an honor code, simply delete this line.
+    'TOS_AND_HONOR': 'tos-and-honor',
     'PRIVACY': 'privacy',
     'PRESS': 'press',
     'BLOG': 'blog',


### PR DESCRIPTION
[LLTV-51](https://youtrack.raccoongang.com/issue/LLTV-51) - `On the Certificate Preview page, if a user clicks the ToS link, the Example Domain page opens.`

- added `TOS_AND_HONOR` to the `MKTG_URL_LINK_MAP`