### PR TITLE
FLANE-188 If a staff opens the 'Users', 'Courses', 'Staffing and Enro…

### DIFF
--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -10,6 +10,7 @@ from django.utils.translation import ugettext as _
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.axislabels.js')}"></script>
 	<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
 	<script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.13.1/jquery.validate.min.js"></script>
 	<script>
 		$('#action').validate();


### PR DESCRIPTION
[FLANE-188](https://youtrack.raccoongang.com/issue/FLANE-188) - `If a staff opens the 'Users', 'Courses', 'Staffing and Enrollment' tabs of the Sysadmin Dashboard and changes the interface language, the language does not changes.`

- include jquery.cookies to the `sysadmin_dashboard.html`