### PR TITLE
LLTV-51 On the Certificate Preview page, if a user clicks the ToS lin…

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -398,9 +398,16 @@ def get_logo_url(is_secure=True):
 
 def get_tos_and_honor_code_url():
     """
-    Lookup and return terms of services page url
+    Lookup and return terms of services and honor code page url
     """
     return get_url("TOS_AND_HONOR")
+
+
+def get_tos_url():
+    """
+    Lookup and return terms of services page url
+    """
+    return get_url("TOS")
 
 
 def get_privacy_url():

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -585,10 +585,10 @@ def get_certificate_footer_context():
     """
     data = dict()
 
-    # get Terms of Service and Honor Code page url
-    terms_of_service_and_honor_code = branding_api.get_tos_and_honor_code_url()
-    if terms_of_service_and_honor_code != branding_api.EMPTY_URL:
-        data.update({'company_tos_url': terms_of_service_and_honor_code})
+    # get Terms of Service page url
+    terms_of_service_url = branding_api.get_tos_url()
+    if terms_of_service_url != branding_api.EMPTY_URL:
+        data.update({'company_tos_url': terms_of_service_url})
 
     # get Privacy Policy page url
     privacy_policy = branding_api.get_privacy_url()

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -165,7 +165,7 @@ def _update_context_with_basic_info(context, course_id, platform_name, configura
     context['document_title'] = _("Invalid Certificate")
 
     # Translators: The &amp; characters represent an ampersand character and can be ignored
-    context['company_tos_urltext'] = _("Terms of Service &amp; Honor Code")
+    context['company_tos_urltext'] = _("Terms of Service")
 
     # Translators: A 'Privacy Policy' is a legal document/statement describing a website's use of personal information
     context['company_privacy_urltext'] = _("Privacy Policy")


### PR DESCRIPTION
[LLTV-51](https://youtrack.raccoongang.com/issue/LLTV-51) - `On the Certificate Preview page, if a user clicks the ToS link, the Example Domain page opens.`

 - changed certificate footer link from TOS_AND_HONOR to the TOS
 - changed `company_tos_urltext` and `company_tos_url`

