### PR TITLE
[HBI]-234: Fix wiki article revision

### DIFF
--- a/lms/templates/wiki/history.html
+++ b/lms/templates/wiki/history.html
@@ -128,6 +128,7 @@
                       document.revisions_form.r.value='{{ revision.id }}';
                       document.revisions_form.action='{% url 'wiki:preview_revision' article.id %}';
                       $('#previewRevisionModal .switch-to-revision').attr('href', '{% url 'wiki:change_revision' path=urlpath.path article_id=article.id revision_id=revision.id %}');
+                      $('#previewRevisionModal .switch-to-revision').attr('onclick', 'window.location.href=$(this).attr("href")');
                       document.revisions_form.submit();">
                   <span class="icon fa fa-eye" aria-hidden="true"></span>
                   {% trans "Preview this revision" %}


### PR DESCRIPTION
**Description:** Describe in a couple of sentences what this PR adds
Wiki articles won't switch revisions on correspondent buttons click.

**Youtrack:** https://youtrack.raccoongang.com/issue/HBI-234

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] @oksana-slu

**Related Confluence documents:**
- < URL to Confluence document 1 >
- < URL to Confluence document 2 >
- ...
- < URL to Confluence document N >

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation in source code updated
- [ ] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
