### PR TITLE
T-75 A registered parent can't log in if he has one more registered b…

### DIFF
--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -479,8 +479,8 @@ def login_user(request):
             ParentProfile = apps.get_model('tedix_ro', 'ParentProfile')
             try:
                 # parent is logging in
-                student = possibly_authenticated_user.parentprofile.students.filter(user__is_active=False).first()
-                if student:
+                student = possibly_authenticated_user.parentprofile.students.all().first()
+                if student and not student.user.is_active:
                     _handle_failed_authentication(email_user, parent=True)
             except ParentProfile.DoesNotExist:
                 # student is logging in


### PR DESCRIPTION
[T-75](https://youtrack.raccoongang.com/issue/T-75) - `A registered parent can't log in if he has one more registered but not activated child.`

- get first student of parent and log them in