### PR TITLE
[CB-104][HAWTHORN] Add external MKTG urls

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -48,6 +48,8 @@ def marketing_link(name):
         settings.MKTG_URLS
     )
 
+    external_mktg_urls = getattr(settings, 'EXTERNAL_MKTG_URLS', {})
+
     if enable_mktg_site and name in marketing_urls:
         # special case for when we only want the root marketing URL
         if name == 'ROOT':
@@ -58,6 +60,9 @@ def marketing_link(name):
         # e.g. urljoin('http://marketing.com', 'http://open-edx.org/about') >>> 'http://open-edx.org/about'
         return urljoin(marketing_urls.get('ROOT'), marketing_urls.get(name))
     # only link to the old pages when the marketing site isn't on
+    elif not enable_mktg_site and name in external_mktg_urls:
+        # Special case for overriding standard MKTG_URLS
+        return external_mktg_urls[name] or '#'
     elif not enable_mktg_site and name in link_map:
         # don't try to reverse disabled marketing links
         if link_map[name] is not None:

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1101,3 +1101,6 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_c
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)
+
+# Variable for overriding standard MKTG_URLS
+EXTERNAL_MKTG_URLS = ENV_TOKENS.get('EXTERNAL_MKTG_URLS', {})


### PR DESCRIPTION
**Description:**
Add the possibility of changing standard MKTG URLs more dynamically.

**Youtrack:**
https://youtrack.raccoongang.com/issue/CB-104

**Configuration instructions:**
Add to `lms.env.json` new setting named `EXTERNAL_MKTG_URLS`:
```
{
   ...
   "EXTERNAL_MKTG_URLS": {
        "HONOR": "<link>"
    },
   ...
}
```
Provide key values pares for overriding one of the standard URLs. The key must be one of these: `["ABOUT", "BLOG", "CONTACT", "COURSES", "DONATE", "FAQ", "HOW_IT_WORKS", "PRESS", "PRIVACY", "ROOT", "TOS", "WHAT_IS_VERIFIED_CERT"]` and value should be a link to the external resource.
If you want to provide a new external link with dynamical configuration put new key-value pair in `"EXTERNAL_MKTG_URLS"` in `lms.env.json` and in the code use the common function named marketing_link from `edxmako.shortcuts` like that:
```
marketing_link("<MY_EXTERNAL_LINK>")
```
