### PR TITLE
changed version of 'python-social-auth' module to custom version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -93,7 +93,7 @@ git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-cl
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.1#egg=lti_consumer-xblock==1.1.1
 git+https://github.com/edx/edx-proctoring.git@0.17.0#egg=edx-proctoring==0.17.0
 
--e git+https://github.com/raccoongang/python-social-auth.git@v0.2.22#egg=python-social-auth==0.2.22
+-e git+https://github.com/raccoongang/python-social-auth.git@v0.2.22-azuread-tenant#egg=python-social-auth==0.2.22
 
 # Base RG modules
 git+https://github.com/raccoongang/edx-search.git@0.1.2-rg#egg=edx-search==0.1.2.1


### PR DESCRIPTION
changed version of 'python-social-auth' module to custom version with `azuread_tenant` backend

**Description:** https://github.com/raccoongang/python-social-auth/tree/v0.2.22-azuread-tenant - customization with 'azuread_tenant' backend copied from newest version of python-social-auth module (https://github.com/python-social-auth/social-core/blob/master/social_core/backends/azuread_tenant.py)

**Youtrack:** https://youtrack.raccoongang.com/issue/HBKU-28

**Post merge:**
- [x] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
