### PR TITLE
ARROW-92/Redirect_to_the_main_page

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -112,6 +112,9 @@ def courses(request):
 
     if not settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
         raise Http404
+    
+    if not request.GET.get('search_query'):
+        return redirect(reverse('root'))
 
     #  we do not expect this case to be reached in cases where
     #  marketing is enabled or the courses are not browsable


### PR DESCRIPTION
**Description:** Redirect to the main page
Need to change the link of the menu item "Explore courses", which is in the header.

Requirements:

- by clicking on the menu item "Explore courses" a user should reach the main page, that contains 
 categories.

- search on the main page should work

**Youtrack:** [ARROW-92](https://youtrack.raccoongang.com/issue/ARROW-92)

