### PR TITLE
ARROW-92/Redirect_to_the_main_page

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -112,10 +112,7 @@ def courses(request):
 
     if not settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
         raise Http404
-    
-    if not request.GET.get('search_query'):
-        return redirect(reverse('root'))
-
+        
     #  we do not expect this case to be reached in cases where
     #  marketing is enabled or the courses are not browsable
     return courseware.views.views.courses(request)

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -82,7 +82,7 @@ site_status_msg = get_site_status_msg(course_id)
         <%block name="navigation_global_links_authenticated">
           % if settings.FEATURES.get('COURSES_ARE_BROWSABLE_AND_SHOW_PROGRAM_LISTING_NAVIGATE') and context.get('threads') == None:
               <li class="item nav-global-01 nav-global-01-xseries-style">
-                <a class="${'active ' if marketing_link('COURSES') == request.path else ''}tab-nav-link" href="${marketing_link('COURSES')}">${_('Explore courses')}</a>
+                <a class="${'active ' if marketing_link('COURSES') == request.path else ''}tab-nav-link" href="${marketing_link('ROOT')}">${_('Explore courses')}</a>
               </li>
               <li class="tab-nav-item">
                 <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}">
@@ -97,7 +97,7 @@ site_status_msg = get_site_status_msg(course_id)
           % else:
             % if settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing and context.get('threads') == None:
               <li class="item nav-global-01">
-                <a href="${marketing_link('COURSES')}">${_('Explore courses')}</a>
+                <a href="${marketing_link('ROOT')}">${_('Explore courses')}</a>
               </li>
             % endif
             % if show_program_listing:
@@ -159,7 +159,7 @@ site_status_msg = get_site_status_msg(course_id)
           % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
             % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
               <li class="item nav-global-05">
-                <a class="btn" href="/courses">${_("Explore Courses")}</a>
+                <a class="btn" href="/">${_("Explore Courses")}</a>
               </li>
             %endif
             % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -110,7 +110,7 @@ from openedx.core.djangoapps.theming import helpers as theming_helpers
         <p>${_("You are not enrolled in any courses yet.")}</p>
 
         % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
-          <a href="${marketing_link('COURSES')}">
+          <a href="${marketing_link('ROOT')}">
             ${_("Explore courses")}
           </a>
         %endif


### PR DESCRIPTION
**Description:** 
Need to change the link of the menu item "Explore courses", which is in the header
**Requirements:**

- by clicking on the menu item "Explore courses" a user should reach the main page, that contains 
    categories.
- search on the main page should work

**Youtrack:** [ARROW-92](https://youtrack.raccoongang.com/issue/ARROW-92)


