### PR TITLE
T-86/The Manage Courses link must be displayed for logged in users wh…

### DIFF
--- a/themes/red-theme/lms/templates/header/navbar-authenticated.html
+++ b/themes/red-theme/lms/templates/header/navbar-authenticated.html
@@ -17,7 +17,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
-  show_manage_courses = hasattr(user, 'instructorprofile')
+  show_manage_courses = user.is_staff or user.is_superuser
 
   if online_help_token == "instructor":
     help_link = doc_link


### PR DESCRIPTION
[T-86](https://youtrack.raccoongang.com/issue/T-86) The Manage Courses link must be displayed for logged in users who have been provided with the Staff or Superuser status. A user with the Staff or Superuser status can open the Manage Courses page even if the user does not have the Instructor profile.