### PR TITLE
SKILLONOMY-74_Fix_referral_id_for_the_event_referral_signup

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -552,7 +552,7 @@ class Registration(models.Model):
                         'student_id': get_user_id(referral.user),
                         'client_id': getattr(settings, 'EDEOS_API_KEY'),
                         "referral_type": "student_signup",
-                        "referral_id": get_user_id(referral.user),
+                        "referral_id": get_user_id(self.user),
                         "referral_hashkey": referral.hashkey,
                         "event_type_verbose": "referral_signup",
                         "event_type": 5

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -537,6 +537,7 @@ class Registration(models.Model):
         self.user.is_active = True
         self._track_activation()
         self.user.save()
+        self.referral_uid = uuid.uuid4().hex
         log.info(u'User %s (%s) account is successfully activated.', self.user.username, self.user.email)
         # TODO: refactor (mix-in or something)
         activated_link = ActivatedLink.objects.filter(
@@ -552,7 +553,7 @@ class Registration(models.Model):
                         'student_id': get_user_id(referral.user),
                         'client_id': getattr(settings, 'EDEOS_API_KEY'),
                         "referral_type": "student_signup",
-                        "referral_id": self.user.email,  # referee
+                        "referral_id": self.referral_uid,
                         "referral_hashkey": referral.hashkey,
                         "event_type_verbose": "referral_signup",
                         "event_type": 5

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -537,7 +537,6 @@ class Registration(models.Model):
         self.user.is_active = True
         self._track_activation()
         self.user.save()
-        self.referral_uid = uuid.uuid4().hex
         log.info(u'User %s (%s) account is successfully activated.', self.user.username, self.user.email)
         # TODO: refactor (mix-in or something)
         activated_link = ActivatedLink.objects.filter(
@@ -553,7 +552,7 @@ class Registration(models.Model):
                         'student_id': get_user_id(referral.user),
                         'client_id': getattr(settings, 'EDEOS_API_KEY'),
                         "referral_type": "student_signup",
-                        "referral_id": self.referral_uid,
+                        "referral_id": get_user_id(referral.user),
                         "referral_hashkey": referral.hashkey,
                         "event_type_verbose": "referral_signup",
                         "event_type": 5


### PR DESCRIPTION
**Description:** Fix referral_id for the event "referral_signup"
In event # 5  ("referral_signup") in "referral_id" need to change from email to user hash id like in "uid"


Events docs - [table 3](https://docs.google.com/document/d/1iOHaUuQl9SJ4VynuSwyL2Vsvfvv7mWIM4HquXpgOAwc/edit?usp=sharing)

**Youtrack:** [SKILLONOMY-74](https://youtrack.raccoongang.com/issue/SKILLONOMY-74)



**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Register new user
2. after registration copy the activation url from the console
3. put it in other browser url
4. and the function ```def activate()``` will create the uid for the refferal_id
5. import pdb; pdb.set_trace() ->  edeos_referral_store_data["payload"]["referral_id"]

**Reviewers:**
- [ ] @OPersian 
