### PR TITLE
A kryachko/ficus rg fix removed edx repos

### DIFF
--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -13,7 +13,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.translation import ugettext as _, ugettext_noop
 from django.views.decorators.http import require_GET, require_http_methods
-import rfc6266
+import rfc6266_parser
 
 from edxval.api import (
     create_video,
@@ -214,7 +214,7 @@ def video_encodings_download(request, course_key_string):
     # listing for videos uploaded through Studio
     filename = _("{course}_video_urls").format(course=course.id.course)
     # See https://tools.ietf.org/html/rfc6266#appendix-D
-    response["Content-Disposition"] = rfc6266.build_header(
+    response["Content-Disposition"] = rfc6266_parser.build_header(
         filename + ".csv",
         filename_compat="video_urls.csv"
     )

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -68,7 +68,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 rfc6266-parser
 
 # Used for testing
-git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
+git+https://github.com/edx/lettuce.git@0.2.22#egg=lettuce==0.2.22
 
 # Our libraries:
 git+https://github.com/edx/XBlock.git@xblock-0.4.13#egg=XBlock==0.4.13

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -65,8 +65,7 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 # The officially released version of django-debug-toolbar-mongo doesn't support DJDT 1.x. This commit does.
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
 
-# NOTE (CCB): This must remain. There is one commit on the upstream repo that has not been released to PyPI.
-git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
+rfc6266-parser
 
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002


### PR DESCRIPTION
Sync `a-kryachko/ficus-rg-fix-removed-edx-repos` with newly added `merck-ficus-stage`