### PR TITLE
T 107 - If an instructor does not have a full name, a sysadmin sees an item with no text.

### DIFF
--- a/common/djangoapps/tedix_ro/models.py
+++ b/common/djangoapps/tedix_ro/models.py
@@ -55,7 +55,7 @@ class UserProfile(models.Model):
         abstract = True
 
     def __unicode__(self):
-        return u'{}'.format(self.user.profile.name)
+        return u'{}'.format(self.user.profile.name or self.user.username)
 
 
 class InstructorProfile(UserProfile):


### PR DESCRIPTION
T-107 - If an instructor does not have a full name, a sysadmin sees an item with no text.
 **Description**
_admin/tedix_ro/studentprofile/5/change_
If an instructor does not have a full name, a sysadmin sees an item with no text.
    ***AR:*** an instructor's full name is used
    ***ER:*** an instructor's username is used
Youtrack [T-107](https://youtrack.raccoongang.com/issue/T-107)