### PR TITLE
UOL-18_404 fix the bug ' error on contact technical support ' 

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -115,7 +115,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'third_party_auth': _third_party_auth_context(request, redirect_to),
             'third_party_auth_hint': third_party_auth_hint or '',
             'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
-            'support_link': configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK),
+            'support_link': configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK) or settings.SUPPORT_SITE_LINK,
 
             # Include form descriptions retrieved from the user API.
             # We could have the JS client make these requests directly,


### PR DESCRIPTION
**Description:** 
after click on  "contact technical support." user should be redirected on _technical support_ page or on the Home page. 
Link for the _technical support_  page on prod is "https://london.ac.uk/contact-us"
**Youtrack:** [UOL-18](https://youtrack.raccoongang.com/issue/UOL-18)

