### PR TITLE
[COMMON BUG] register bookmarks celery task

### DIFF
--- a/openedx/core/djangoapps/bookmarks/apps.py
+++ b/openedx/core/djangoapps/bookmarks/apps.py
@@ -32,3 +32,7 @@ class BookmarksConfig(AppConfig):
     def ready(self):
         # Register the signals handled by bookmarks.
         from . import signals
+        # Register the tasks handled by signals
+        from . import tasks
+        from cms import CELERY_APP
+        CELERY_APP.tasks.register(task=tasks.update_xblocks_cache)

--- a/openedx/core/djangoapps/bookmarks/apps.py
+++ b/openedx/core/djangoapps/bookmarks/apps.py
@@ -32,7 +32,7 @@ class BookmarksConfig(AppConfig):
     def ready(self):
         # Register the signals handled by bookmarks.
         from . import signals
-        # Register the tasks handled by signals
+        # Register the tasks handled by signals.
         from . import tasks
         from cms import CELERY_APP
         CELERY_APP.tasks.register(task=tasks.update_xblocks_cache)


### PR DESCRIPTION
**Description:** Register bookmarks celery tasks for update cms xblock cache.

**Youtrack:** [ticket](https://youtrack.raccoongang.com/issue/CB-112)

**Testing instructions:**

1. Open CMS and SignIN
2. Create course and add Section/Subsection/Unit
3. Open LMS and login
4. Enroll on created course and add this unit in bookmarks on the "course" page LMS
5. Change names for Section/Subsection/Unit on Section1/Subsection1/Unit1
6. Check "Bookmarks" page