### PR TITLE
changed version of social-auth-core python module to 1.6.0 due to Facebook policy changes

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -99,7 +99,7 @@ django-memcached-hashring==0.1.2
 python-openid==2.2.5
 python-dateutil==2.1
 social-auth-app-django==1.2.0
-social-auth-core==1.4.0
+social-auth-core==1.6.0
 pytz==2016.7
 pysrt==0.4.7
 PyYAML==3.12


### PR DESCRIPTION
**Description:** Fix for strict Redirect URL in Facebook third-party integration

**Youtrack:** there is no ticket

**Issue description and fix**: https://github.com/python-social-auth/social-core/pull/147

**Testing instructions:**

1. Open sign-in page
2. Login via Facebook
3. Expect successful login
4. Failed is this message is appearing: `URL Blocked: This redirect failed because the redirect URI is not whitelisted in the app’s Client OAuth Settings.`
