### PR TITLE
UOL-23_sysadmin Need to delete Django version from the tab 

### DIFF
--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -215,8 +215,5 @@ textarea {
 %endif
 
   </section>
-  <div style="text-align:right; float: right"><span id="djangopid">'Django PID': ${djangopid}</span>
-  ## Translators: A version number appears after this string
-  | <span id="edxver">${_('Platform Version')}: ${edx_platform_version}</span></div>
 </div>
 </section>


### PR DESCRIPTION
**Description:** UOL-23_sysadmin Need to delete Django version from the tab

[**UOL-23**](https://youtrack.raccoongang.com/issue/UOL-23)

**Testing instructions:**

1. Open page http://localhost:8000/sysadmin/
2. Scroll to the footer and check the footer. For _"'Django PID': 35595 | Platform Version:"_
3. Shouldn't be any Django version and Platform Version 
![image](https://user-images.githubusercontent.com/48920645/59188162-b416a080-8b7f-11e9-9835-900b490f0794.png)



**Reviewers:**
- [ ] @sendr 
- [ ] @cmltaWt0 
- [ ] @oleksandra-martyntseva 