### PR TITLE
LSE-31 If a user opens the About page of a course that has the visibility setting set to 'none', a page with no styling opens.

### DIFF
--- a/lms/djangoapps/courseware/middleware.py
+++ b/lms/djangoapps/courseware/middleware.py
@@ -1,9 +1,9 @@
 """
 Middleware for the courseware app
 """
-
-from django.shortcuts import redirect
+import crum
 from django.core.urlresolvers import reverse
+from django.shortcuts import redirect
 
 from courseware.courses import UserNotEnrolled
 
@@ -13,6 +13,7 @@ class RedirectUnenrolledMiddleware(object):
     Catch UserNotEnrolled errors thrown by `get_course_with_access` and redirect
     users to the course about page
     """
+    
     def process_exception(self, _request, exception):
         if isinstance(exception, UserNotEnrolled):
             course_key = exception.course_key
@@ -22,3 +23,14 @@ class RedirectUnenrolledMiddleware(object):
                     args=[course_key.to_deprecated_string()]
                 )
             )
+
+
+class CustomCurrentRequestUserMiddleware(crum.CurrentRequestUserMiddleware):
+    """
+    Overide the process_exception() method in CurrentRequestUserMiddleware class for
+    using custom theme with 404 page.
+    """
+
+    def process_exception(self, request, exception):
+        # overided method to not clear the request
+        pass

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1107,8 +1107,7 @@ simplefilter('ignore')
 ################################# Middleware ###################################
 
 MIDDLEWARE_CLASSES = (
-    'crum.CurrentRequestUserMiddleware',
-
+    'courseware.middleware.CustomCurrentRequestUserMiddleware',
     'request_cache.middleware.RequestCache',
     'newrelic_custom_metrics.middleware.NewRelicCustomMetrics',
 


### PR DESCRIPTION
**Description:** Rewrite the middleware class _curl.CurrentRequestUserMiddleware_ and _process_exception_ method. The main idea use Custom theme in rendering 404.html page.

**Youtrack:** [LSE-31](https://youtrack.raccoongang.com/issue/LSE-31)

**Testing instructions:**

1. Open CMS -> any course->Advanced settings -> Visibility 'none'
2. Open LMS -> 'current course'/about/ 
3. Should be 404 page with current theme

**Reviewers:**
- [ ] @sendr 