### PR TITLE
[5hart-ficus] Add catalog_visibility for course discovery

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -591,6 +591,7 @@ class CourseAboutSearchIndexer(object):
             'course': course_id,
             'content': {},
             'image_url': course_image_url(course),
+            'catalog_visibility': course.catalog_visibility
         }
 
         # load data for all of the 'about' modules for this course into a dictionary

--- a/lms/static/js/discovery/collection.js
+++ b/lms/static/js/discovery/collection.js
@@ -17,6 +17,7 @@
             page: 0,
             url: '/search/course_discovery/',
             fetchXhr: null,
+            catalog_visibility: 'both',
 
             performSearch: function(searchTerm, facets) {
                 this.fetchXhr && this.fetchXhr.abort();
@@ -59,7 +60,8 @@
                 var data = {
                     search_string: this.searchTerm,
                     page_size: this.pageSize,
-                    page_index: pageNumber
+                    page_index: pageNumber,
+                    catalog_visibility: this.catalog_visibility
                 };
                 if (this.selectedFacets.length > 0) {
                     this.selectedFacets.each(function(facet) {

--- a/lms/static/js/discovery/models/search_state.js
+++ b/lms/static/js/discovery/models/search_state.js
@@ -15,6 +15,7 @@
             searchTerm: '',
             terms: {},
             jqhxr: null,
+            catalog_visibility: 'both',
 
             initialize: function() {
                 this.discovery = new CourseDiscovery();
@@ -63,7 +64,8 @@
                 var data = {
                     search_string: this.searchTerm,
                     page_size: this.pageSize,
-                    page_index: pageIndex
+                    page_index: pageIndex,
+                    catalog_visibility: this.catalog_visibility
                 };
                 _.extend(data, this.terms);
                 return data;
@@ -131,7 +133,8 @@
                         data: {
                             search_string: '',
                             page_size: this.pageSize,
-                            page_index: 0
+                            page_index: 0,
+                            catalog_visibility: this.catalog_visibility
                         },
                         success: function(model, response, options) {
                             deferred.resolveWith(self, [model]);

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -55,7 +55,7 @@ edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.1
 edx-rest-api-client==1.6.0
-edx-search==0.1.2
+#edx-search==0.1.2
 facebook-sdk==0.4.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -55,7 +55,6 @@ edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.1
 edx-rest-api-client==1.6.0
-#edx-search==0.1.2
 facebook-sdk==0.4.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -96,3 +96,5 @@ git+https://github.com/edx/edx-proctoring.git@0.17.0#egg=edx-proctoring==0.17.0
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@v1.2.3#egg=xblock-poll==1.2.3
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.15#egg=xblock-drag-and-drop-v2==2.0.15
+
+-e git+https://github.com/raccoongang/edx-search.git@0.1.2-rg#egg=edx-search


### PR DESCRIPTION
**Description:** Fix course catalog visibility bug. Cherry-pick from [commit](https://github.com/raccoongang/edx-platform/commit/eb52d593091f6f4a5450ae09a9ea6e4ebc670f62).

**Youtrack:** [ticket](https://youtrack.raccoongang.com/issue/5HART-60)

**Configuration instructions:**
Add in lms.env.json these flags, if they don't exists:
 "COURSE_CATALOG_VISIBILITY_PERMISSION": "see_in_catalog",
 "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_about_page",

**Testing instructions:**
1. Open course in studio
2. Go to advanced settings
3. Course Visibility In Catalog value set in "none"
4. Go to the lms courses page
