### PR TITLE
MERCK-27 In Django administration, 500 if a sysadmin deletes categories.

### DIFF
--- a/common/djangoapps/course_category/models.py
+++ b/common/djangoapps/course_category/models.py
@@ -57,7 +57,7 @@ def delete_reindex_course_category(sender, instance, **kwargs):
     category_courses = instance.courses.all()
     if category_courses:
         instance.courses_list = map(lambda x: str(x.id), category_courses)
-    elif instance.courses_list:
+    elif hasattr(instance, 'courses_list'):
         task_reindex_courses.delay(course_keys=instance.courses_list)
 
 


### PR DESCRIPTION
[MERCK-27](https://youtrack.raccoongang.com/issue/MERCK-27) - `In Django administration, 500 if a sysadmin deletes categories.`
[MERCK-28](https://youtrack.raccoongang.com/issue/MERCK-28) - `In Django administration, 500 if a sysadmin deletes the Fundamentals or Modern Desktop Administration categories.`
 - check whether the attr exists `courses_list`
