### PR TITLE
merck 31/merck 48/merck 50

### DIFF
--- a/common/djangoapps/course_category/admin.py
+++ b/common/djangoapps/course_category/admin.py
@@ -21,7 +21,7 @@ class CourseCategoryForm(forms.ModelForm):
 
     def clean_parent(self):
         parent = self.cleaned_data['parent']
-        if parent in self.instance.get_descendants(include_self=True):
+        if self.instance.id and parent in self.instance.get_descendants(include_self=True):
             self.add_error('parent', "A parent may not be made a child of itself")
         return parent
 

--- a/common/djangoapps/course_category/admin.py
+++ b/common/djangoapps/course_category/admin.py
@@ -19,6 +19,12 @@ class CourseMultipleModelChoiceField(forms.ModelMultipleChoiceField):
 class CourseCategoryForm(forms.ModelForm):
     courses = CourseMultipleModelChoiceField(queryset=CourseOverview.objects.all(), required=False)
 
+    def clean_parent(self):
+        parent = self.cleaned_data['parent']
+        if parent in self.instance.get_descendants(include_self=True):
+            self.add_error('parent', "A parent may not be made a child of itself")
+        return parent
+
 
 class CourseCategoryAdmin(DjangoMpttAdmin):
     form = CourseCategoryForm

--- a/common/djangoapps/course_category/search_engine.py
+++ b/common/djangoapps/course_category/search_engine.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django.conf import settings
+from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from search.elastic import ElasticSearchEngine
 
 from .models import CourseCategory
@@ -9,13 +10,13 @@ from .models import CourseCategory
 class CourseCategorySearchEngine(ElasticSearchEngine):
 
     def search(self, **kwargs):
-        """ 
+        """
         Override default engine just to reorder categories
         """
         results = super(CourseCategorySearchEngine, self).search(**kwargs)
 
         if 'category' in settings.COURSE_DISCOVERY_FILTERS:
-            categories = CourseCategory.objects.filter(parent=None, courses__isnull=False)
+            categories = CourseCategory.objects.filter(parent=None).exclude(courses=CourseKeyField.Empty)
             facets_category_terms = results.get('facets', {}).get('category', {}).get('terms')
             if facets_category_terms:
                 terms = OrderedDict()

--- a/common/djangoapps/course_category/search_engine.py
+++ b/common/djangoapps/course_category/search_engine.py
@@ -1,0 +1,26 @@
+from collections import OrderedDict
+
+from django.conf import settings
+from search.elastic import ElasticSearchEngine
+
+from .models import CourseCategory
+
+
+class CourseCategorySearchEngine(ElasticSearchEngine):
+
+    def search(self, **kwargs):
+        """ 
+        Override default engine just to reorder categories
+        """
+        results = super(CourseCategorySearchEngine, self).search(**kwargs)
+
+        if 'category' in settings.COURSE_DISCOVERY_FILTERS:
+            categories = CourseCategory.objects.filter(parent=None, courses__isnull=False)
+            facets_category_terms = results.get('facets', {}).get('category', {}).get('terms')
+            if facets_category_terms:
+                terms = OrderedDict()
+                for category in categories:
+                    if facets_category_terms.get(category.name):
+                        terms[category.name] = facets_category_terms.get(category.name)
+                results['facets']['category']['terms'] = terms
+        return results

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -770,7 +770,7 @@ if FEATURES.get('ENABLE_COURSEWARE_SEARCH') or \
    FEATURES.get('ENABLE_COURSE_DISCOVERY') or \
    FEATURES.get('ENABLE_TEAMS'):
     # Use ElasticSearch as the search engine herein
-    SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+    SEARCH_ENGINE = "course_category.search_engine.CourseCategorySearchEngine"
 
 ELASTIC_SEARCH_CONFIG = ENV_TOKENS.get('ELASTIC_SEARCH_CONFIG', [{}])
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -371,7 +371,7 @@ FEATURES = {
     'BULK_EMAIL_FROM_DIFFERENT_ADDRESSES': False,
 }
 
-COURSE_DISCOVERY_FILTERS = ["org", "language", "modes", "category"]
+COURSE_DISCOVERY_FILTERS = ["category"]
 # Ignore static asset files on import which match this pattern
 ASSET_IGNORE_REGEX = r"(^\._.*$)|(^\.DS_Store$)|(^.*~$)"
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -372,6 +372,13 @@ FEATURES = {
 }
 
 COURSE_DISCOVERY_FILTERS = ["category"]
+
+COURSE_DISCOVERY_MEANINGS = {
+    'category': {
+        'name': 'Categories',
+    }
+}
+
 # Ignore static asset files on import which match this pattern
 ASSET_IGNORE_REGEX = r"(^\._.*$)|(^\.DS_Store$)|(^.*~$)"
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -157,7 +157,7 @@ FEATURES['LICENSING'] = True
 
 ########################## Courseware Search #######################
 FEATURES['ENABLE_COURSEWARE_SEARCH'] = True
-SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+SEARCH_ENGINE = "course_category.search_engine.CourseCategorySearchEngine"
 
 
 ########################## Dashboard Search #######################
@@ -170,22 +170,6 @@ FEATURES['CERTIFICATES_HTML_VIEW'] = True
 
 ########################## Course Discovery #######################
 LANGUAGE_MAP = {'terms': {lang: display for lang, display in ALL_LANGUAGES}, 'name': 'Language'}
-COURSE_DISCOVERY_MEANINGS = {
-    'org': {
-        'name': 'Organization',
-    },
-    'modes': {
-        'name': 'Course Type',
-        'terms': {
-            'honor': 'Honor',
-            'verified': 'Verified',
-        },
-    },
-    'language': LANGUAGE_MAP,
-    'category': {
-        'name': 'Categories',
-    }
-}
 
 FEATURES['ENABLE_COURSE_DISCOVERY'] = True
 # Setting for overriding default filtering facets for Course discovery


### PR DESCRIPTION
[MERCK-31](https://youtrack.raccoongang.com/issue/MERCK-31) 500 if a sysadmin sets the same category as a parent.
[MERCK-48](https://youtrack.raccoongang.com/issue/MERCK-48) In the catalogue, only categories are displayed in filters.
[MERCK-50](https://youtrack.raccoongang.com/issue/MERCK-50) On the main page and in the catalogue's filters, categories must be displayed in the same order.