### PR TITLE
SU-61, 62, 64 Fix. Update CourseOverview when updating the course in CMS

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -960,6 +960,10 @@ INSTALLED_APPS = (
 
     # Unusual migrations
     'database_fixups',
+
+    'course_category',
+
+    'django_mptt_admin',
 )
 
 

--- a/common/djangoapps/course_category/models.py
+++ b/common/djangoapps/course_category/models.py
@@ -57,7 +57,7 @@ def delete_reindex_course_category(sender, instance, **kwargs):
     category_courses = instance.courses.all()
     if category_courses:
         instance.courses_list = map(lambda x: str(x.id), category_courses)
-    elif instance.courses_list:
+    elif hasattr(instance, 'courses_list'):
         task_reindex_courses.delay(course_keys=instance.courses_list)
 
 

--- a/common/djangoapps/course_category/tasks.py
+++ b/common/djangoapps/course_category/tasks.py
@@ -18,3 +18,12 @@ def task_reindex_courses(category_id=None, course_keys=None):
     for course_key in courses:
         course_key = CourseKey.from_string(course_key)
         CoursewareSearchIndexer.do_course_reindex(modulestore(), course_key)
+
+
+@task
+def task_add_categories(category_names, course_id):
+    from course_category.models import CourseCategory
+    for category_name in category_names:
+        category = CourseCategory.objects.filter(name=category_name).first()
+        if category:
+            category.courses.add(CourseKey.from_string(course_id))

--- a/openedx/core/djangoapps/bookmarks/tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tasks.py
@@ -140,7 +140,7 @@ def _update_xblocks_cache(course_key):
                 update_block_cache_if_needed(block_cache, block_data)
 
 
-@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblock_cache')
+@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblocks_cache')
 def update_xblocks_cache(course_id):
     """
     Update the XBlocks cache for a course.


### PR DESCRIPTION
- [SU-61](https://youtrack.raccoongang.com/issue/SU-61) If a staff changes the schedule of a course in a category, the course schedule dates are not displayed updated in LMS administration.
- [SU-62](https://youtrack.raccoongang.com/issue/SU-62) If a staff changes the Course Start date and/or the Course Image in CMS, the new Course Start date and/or the new Course Image are not displayed on the main page.
- [SU-64](https://youtrack.raccoongang.com/issue/SU-64) 500 if a sysadmin deletes a category in LMS Administration.
- Fix. If a course creator changes a course schedule in CMS, the course becomes deleted from a category.