### PR TITLE
MERCK-54 Incorrect error message when a user set a child category as a parent in LMS Administration.

### DIFF
--- a/common/djangoapps/course_category/admin.py
+++ b/common/djangoapps/course_category/admin.py
@@ -22,7 +22,10 @@ class CourseCategoryForm(forms.ModelForm):
     def clean_parent(self):
         parent = self.cleaned_data['parent']
         if self.instance.id and parent in self.instance.get_descendants(include_self=True):
-            self.add_error('parent', "A parent may not be made a child of itself")
+            self.add_error('parent',
+                'A category or subcategory can\'t be a parent of itself. '
+                'A subcategory can\'t be a parent of its parent category.'
+            )
         return parent
 
 


### PR DESCRIPTION
[MERCK-54](https://youtrack.raccoongang.com/issue/MERCK-54) Incorrect error message when a user set a child category as a parent in LMS Administration.