### PR TITLE
ficus-rg: SMTP CRAM-MD5 authorization fix

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -20,6 +20,7 @@ import os
 
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
+from django.utils.encoding import force_str
 
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON
 # configuration files are read during startup.
@@ -282,7 +283,8 @@ if 'DJFS' in AUTH_TOKENS and AUTH_TOKENS['DJFS'] is not None:
         DJFS['url_root'] = DJFS['url_root'].format(platform_revision=EDX_PLATFORM_REVISION)
 
 EMAIL_HOST_USER = AUTH_TOKENS.get('EMAIL_HOST_USER', EMAIL_HOST_USER)
-EMAIL_HOST_PASSWORD = AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', EMAIL_HOST_PASSWORD)
+# force_str ised to fix this issue - https://code.djangoproject.com/ticket/27131
+EMAIL_HOST_PASSWORD = force_str(AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', EMAIL_HOST_PASSWORD))
 
 AWS_SES_REGION_NAME = ENV_TOKENS.get('AWS_SES_REGION_NAME', 'us-east-1')
 AWS_SES_REGION_ENDPOINT = ENV_TOKENS.get('AWS_SES_REGION_ENDPOINT', 'email.us-east-1.amazonaws.com')

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -283,7 +283,7 @@ if 'DJFS' in AUTH_TOKENS and AUTH_TOKENS['DJFS'] is not None:
         DJFS['url_root'] = DJFS['url_root'].format(platform_revision=EDX_PLATFORM_REVISION)
 
 EMAIL_HOST_USER = AUTH_TOKENS.get('EMAIL_HOST_USER', EMAIL_HOST_USER)
-# force_str ised to fix this issue - https://code.djangoproject.com/ticket/27131
+# convert from unicode to ascii to fix this issue - https://code.djangoproject.com/ticket/27131
 EMAIL_HOST_PASSWORD = force_str(AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', EMAIL_HOST_PASSWORD))
 
 AWS_SES_REGION_NAME = ENV_TOKENS.get('AWS_SES_REGION_NAME', 'us-east-1')

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -28,6 +28,7 @@ import os
 
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
+from django.utils.encoding import force_str
 
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON
 # configuration files are read during startup.
@@ -561,7 +562,8 @@ DOC_STORE_CONFIG = AUTH_TOKENS.get('DOC_STORE_CONFIG', DOC_STORE_CONFIG)
 MONGODB_LOG = AUTH_TOKENS.get('MONGODB_LOG', {})
 
 EMAIL_HOST_USER = AUTH_TOKENS.get('EMAIL_HOST_USER', '')  # django default is ''
-EMAIL_HOST_PASSWORD = AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', '')  # django default is ''
+# force_str ised to fix this issue - https://code.djangoproject.com/ticket/27131
+EMAIL_HOST_PASSWORD = force_str(AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', '')) # django default is ''
 
 # Datadog for events!
 DATADOG = AUTH_TOKENS.get("DATADOG", {})

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -562,7 +562,7 @@ DOC_STORE_CONFIG = AUTH_TOKENS.get('DOC_STORE_CONFIG', DOC_STORE_CONFIG)
 MONGODB_LOG = AUTH_TOKENS.get('MONGODB_LOG', {})
 
 EMAIL_HOST_USER = AUTH_TOKENS.get('EMAIL_HOST_USER', '')  # django default is ''
-# force_str ised to fix this issue - https://code.djangoproject.com/ticket/27131
+# convert from unicode to ascii to fix this issue - https://code.djangoproject.com/ticket/27131
 EMAIL_HOST_PASSWORD = force_str(AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', '')) # django default is ''
 
 # Datadog for events!


### PR DESCRIPTION
**Description:** Fix for Django<2.2.2 bug described here https://code.djangoproject.com/ticket/27131

**Youtrack:**
- https://youtrack.raccoongang.com/issue/F21C-4
- https://youtrack.raccoongang.com/issue/MERCK-23

**Testing instructions:**

to test OpenEdx application must be configured to use SMTP server with available CRAM-MD5 authorization scheme.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green

**Post merge:**
- [x] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
