### PR TITLE
[GIJIMA] Adds scorm-xblock to the installation requirements

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -102,3 +102,6 @@ git+https://github.com/raccoongang/edx-search.git@0.1.2-rg#egg=edx-search==0.1.2
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@v1.2.3#egg=xblock-poll==1.2.3
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.15#egg=xblock-drag-and-drop-v2==2.0.15
+
+# Scorm Xblock
+git+https://github.com/raccoongang/edx_xblock_scorm.git@v1.0.2#egg=edx_xblock_scorm==1.0.2


### PR DESCRIPTION
**Description:** Adds branch gijima-ficus-rg to origin, adds scorm-xblock installation

**Youtrack:** [ticket](https://youtrack.raccoongang.com/issue/GIJIMA-31), [ticket for review](https://youtrack.raccoongang.com/issue/GIJIMA-34)

**Addition information:** [Dev-Ops info](https://raccoongang.atlassian.net/wiki/spaces/tech/pages/1164574734/Gijima+DevOps+Info), [scorm-xblock info](https://github.com/raccoongang/edx_xblock_scorm)
