### PR TITLE
T-162 In LMS Administration, there are a lot of not required extensions that a user can choose in instructor profiles export menu.

### DIFF
--- a/common/djangoapps/tedix_ro/admin.py
+++ b/common/djangoapps/tedix_ro/admin.py
@@ -139,6 +139,10 @@ class InstructorProfileResource(resources.ModelResource):
 class InstructorProfileAdmin(ImportExportModelAdmin):
     form = InstructorProfileForm
     resource_class = InstructorProfileResource
+    formats = (
+        base_formats.CSV,
+        base_formats.JSON,
+    )
     search_fields = ['user__username', 'user__profile__name']
 
 


### PR DESCRIPTION
[T-162](https://youtrack.raccoongang.com/issue/T-162) In LMS Administration, there are a lot of not required extensions that a user can choose in instructor profiles export menu.
- list formats for export instructor profiles changed