### PR TITLE
IRONWOOD-26 If a user changes the speed of a video, logs out, logs in, opens the same video, and playbacks it, the video speed is in fact 1.0x, but the previously set one is displayed.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -708,12 +708,11 @@ function(VideoPlayer, i18n, moment, _) {
             1.25: '1.50', // HTML5 or Youtube Flash -> Youtube HTML5
             '2.0': '1.50'   // Youtube HTML5 -> HTML5 or Youtube Flash
         };
-
-        if (_.contains(this.speeds, newSpeed)) {
-            this.speed = newSpeed;
+        if (_.contains(this.speeds, newSpeed.toString())) {
+            this.speed = parseFloat(newSpeed);
         } else {
             newSpeed = map[newSpeed];
-            this.speed = _.contains(this.speeds, newSpeed) ? newSpeed : '1.0';
+            this.speed = _.contains(this.speeds, newSpeed) ? parseFloat(newSpeed) : 1.0;
         }
     }
 

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -259,6 +259,8 @@
         },
 
         setActiveSpeed: function(speed) {
+            var floatSpeed = parseFloat(speed);
+            speed = Number.isInteger(floatSpeed) ? floatSpeed.toFixed(1) : floatSpeed.toFixed(2);
             var speedOption = this.speedsContainer.find('li[data-speed="' + speed + '"]');
 
             speedOption.addClass('is-active')


### PR DESCRIPTION
[IRONWOOD-26](https://youtrack.raccoongang.com/issue/IRONWOOD-26) If a user changes the speed of a video, logs out, logs in, opens the same video, and playbacks it, the video speed is in fact 1.0x, but the previously set one is displayed.
- cherry-pick commit: be06b38c81847b9e2ef2955e1797a7d656e93107
LSE-29 If a user changes the speed of a video, logs out, logs in, opens the same video, and playbacks it, the video speed is in fact 1.0x, but the previously set one is displayed.