### PR TITLE
html versions of email templates added

### DIFF
--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -381,11 +381,17 @@ def send_reactivation_email_for_user(user):
     subject = render_to_string('emails/activation_email_subject.txt', context)
     subject = ''.join(subject.splitlines())
     message = render_to_string('emails/activation_email.txt', context)
+
+    try:
+        html_message = render_to_string('emails/activation_email.html', context)
+    except:
+        html_message = None
+
     from_address = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
     from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS', from_address)
 
     try:
-        user.email_user(subject, message, from_address)
+        user.email_user(subject, message, from_address, html_message=html_message)
     except Exception:  # pylint: disable=broad-except
         log.error(
             u'Unable to send reactivation email from "%s" to "%s"',

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -266,13 +266,25 @@ def compose_and_send_activation_email(user, profile, user_registration=None):
     # Email subject *must not* contain newlines
     subject = ''.join(subject.splitlines())
     message_for_activation = render_to_string('emails/activation_email.txt', context)
+
+    try:
+        html_message_for_activation = render_to_string('emails/activation_email.html', context)
+    except:
+        html_message_for_activation = None
+
     from_address = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
     from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS', from_address)
-    if settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL'):
-        dest_addr = settings.FEATURES['REROUTE_ACTIVATION_EMAIL']
-        message_for_activation = ("Activation for %s (%s): %s\n" % (user, user.email, profile.name) +
-                                  '-' * 80 + '\n\n' + message_for_activation)
-    send_activation_email.delay(subject, message_for_activation, from_address, dest_addr)
+
+    try:
+        if settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL'):
+            dest_addr = settings.FEATURES['REROUTE_ACTIVATION_EMAIL']
+            message_for_activation = ("Activation for %s (%s): %s\n" % (user, user.email, profile.name) +
+                        '-' * 80 + '\n\n' + message_for_activation)
+            mail.send_mail(subject, message_for_activation, from_address, [dest_addr], fail_silently=False, html_message=html_message_for_activation)
+        else:
+            user.email_user(subject, message_for_activation, from_address, html_message=html_message_for_activation)
+    except Exception:  # pylint: disable=broad-except
+        log.error(u'Unable to send activation email to user from "%s"', from_address, exc_info=True)
 
 
 @login_required
@@ -1288,12 +1300,17 @@ def do_email_change_request(user, new_email, activation_key=None):
 
     message = render_to_string('emails/email_change.txt', context)
 
+    try:
+        html_message = render_to_string('emails/email_change.html', context)
+    except:
+        html_message = None
+
     from_address = configuration_helpers.get_value(
         'email_from_address',
         settings.DEFAULT_FROM_EMAIL
     )
     try:
-        mail.send_mail(subject, message, from_address, [pec.new_email])
+        mail.send_mail(subject, message, from_address, [pec.new_email], html_message=html_message)
     except Exception:
         log.error(u'Unable to send email activation link to user from "%s"', from_address, exc_info=True)
         raise ValueError(_('Unable to send email activation link. Please try again later.'))
@@ -1343,6 +1360,12 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
         subject = render_to_string('emails/email_change_subject.txt', address_context)
         subject = ''.join(subject.splitlines())
         message = render_to_string('emails/confirm_email_change.txt', address_context)
+        try:
+            html_message = render_to_string('emails/confirm_email_change.html', address_context)
+        except:
+            html_message = None
+
+
         u_prof = UserProfile.objects.get(user=user)
         meta = u_prof.get_meta()
         if 'old_emails' not in meta:
@@ -1355,7 +1378,7 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
             user.email_user(
                 subject,
                 message,
-                configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
+                configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL), html_message=html_message
             )
         except Exception:    # pylint: disable=broad-except
             log.warning('Unable to send confirmation email to old address', exc_info=True)
@@ -1371,7 +1394,7 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
             user.email_user(
                 subject,
                 message,
-                configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
+                configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL), html_message=html_message
             )
         except Exception:  # pylint: disable=broad-except
             log.warning('Unable to send confirmation email to new address', exc_info=True)

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -452,39 +452,53 @@ def send_mail_to_student(student, param_dict, language=None):
     email_template_dict = {
         'allowed_enroll': (
             'emails/enroll_email_allowedsubject.txt',
-            'emails/enroll_email_allowedmessage.txt'
+            'emails/enroll_email_allowedmessage.txt',
+            'emails/enroll_email_allowedmessage.html'
         ),
         'enrolled_enroll': (
             'emails/enroll_email_enrolledsubject.txt',
-            'emails/enroll_email_enrolledmessage.txt'
+            'emails/enroll_email_enrolledmessage.txt',
+            'emails/enroll_email_enrolledmessage.html'
         ),
         'allowed_unenroll': (
             'emails/unenroll_email_subject.txt',
-            'emails/unenroll_email_allowedmessage.txt'
+            'emails/unenroll_email_allowedmessage.txt',
+            'emails/unenroll_email_allowedmessage.html'
         ),
         'enrolled_unenroll': (
             'emails/unenroll_email_subject.txt',
-            'emails/unenroll_email_enrolledmessage.txt'
+            'emails/unenroll_email_enrolledmessage.txt',
+            'emails/unenroll_email_enrolledmessage.html'
         ),
         'add_beta_tester': (
             'emails/add_beta_tester_email_subject.txt',
-            'emails/add_beta_tester_email_message.txt'
+            'emails/add_beta_tester_email_message.txt',
+            'emails/add_beta_tester_email_message.html'
         ),
         'remove_beta_tester': (
             'emails/remove_beta_tester_email_subject.txt',
-            'emails/remove_beta_tester_email_message.txt'
+            'emails/remove_beta_tester_email_message.txt',
+            'emails/remove_beta_tester_email_message.html'
         ),
         'account_creation_and_enrollment': (
             'emails/enroll_email_enrolledsubject.txt',
-            'emails/account_creation_and_enroll_emailMessage.txt'
+            'emails/account_creation_and_enroll_emailMessage.txt',
+            'emails/account_creation_and_enroll_emailMessage.html'
         ),
     }
 
-    subject_template, message_template = email_template_dict.get(message_type, (None, None))
+    subject_template, message_template, html_message_template = email_template_dict.get(message_type, (None, None, None))
     if subject_template is not None and message_template is not None:
         subject, message = render_message_to_string(
             subject_template, message_template, param_dict, language=language
         )
+
+
+    try:
+        subject, html_message = render_message_to_string(subject_template,
+                                html_message_template, param_dict, language=language)
+    except:
+        html_message = None
 
     if subject and message:
         # Remove leading and trailing whitespace from body
@@ -497,7 +511,7 @@ def send_mail_to_student(student, param_dict, language=None):
             settings.DEFAULT_FROM_EMAIL
         )
 
-        send_mail(subject, message, from_address, [student], fail_silently=False)
+        send_mail(subject, message, from_address, [student], fail_silently=False, html_message=html_message)
 
 
 def render_message_to_string(subject_template, message_template, param_dict, language=None):

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1077,7 +1077,12 @@ class SubmitPhotosView(View):
         to_address = user.email
 
         try:
-            send_mail(subject, message, from_address, [to_address], fail_silently=False)
+            html_message = render_to_string('emails/photo_submission_confirmation.html', context)
+        except:
+            html_message = None
+
+        try:
+            send_mail(subject, message, from_address, [to_address], fail_silently=False, html_message=html_message)
         except:  # pylint: disable=bare-except
             # We catch all exceptions and log them.
             # It would be much, much worse to roll back the transaction due to an uncaught

--- a/lms/templates/emails/account_creation_and_enroll_emailMessage.html
+++ b/lms/templates/emails/account_creation_and_enroll_emailMessage.html
@@ -1,0 +1,25 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Welcome to {course_name}").format(course_name=course.display_name_with_default_escaped)}
+</p>
+<p>
+${_("To get started, please visit https://{site_name}. The login information for your account follows.").format(site_name=site_name)}
+</p>
+<p>
+<pre>
+${_("email: {email}").format(email=email_address)}
+${_("password: {password}").format(password=password)}
+</pre>
+</p>
+<p>
+${_("It is recommended that you change your password.")}
+</p>
+<p>
+${_("Sincerely yours,"
+""
+"The {course_name} Team").format(course_name=course.display_name_with_default_escaped)}
+</p>
+</%block>

--- a/lms/templates/emails/activation_email.html
+++ b/lms/templates/emails/activation_email.html
@@ -1,0 +1,32 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+<%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
+
+<%block name="message">
+<p>
+${_("Thank you for creating an account with {platform_name}!").format(
+    platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+)}
+</p>
+<p>
+${_("There's just one more step before you can enroll in a course: "
+    "you need to activate your {platform_name} account. To activate "
+    "your account, click the following link. If that doesn't work, "
+    "copy and paste the link into your browser's address bar.").format(
+        platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+    )}
+</p>
+<p>
+% if is_secure:
+  https://${ site }/activate/${ key }
+% else:
+  http://${ site }/activate/${ key }
+% endif
+</p>
+<p>
+${_("If you didn't create an account, you don't need to do anything; you "
+      "won't receive any more email from us. If you need assistance, please "
+      "do not reply to this email message. Check the help section of the "
+      "{platform_name} website.").format(platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME))}
+</p>
+</%block>

--- a/lms/templates/emails/add_beta_tester_email_message.html
+++ b/lms/templates/emails/add_beta_tester_email_message.html
@@ -1,0 +1,33 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Dear {full_name}").format(full_name=full_name)}
+</p>
+<p>
+${_("You have been invited to be a beta tester for {course_name} at {site_name} by a "
+	"member of the course staff.").format(
+		course_name=course.display_name_with_default_escaped,
+		site_name=site_name
+	)}
+</p>
+<p>
+% if auto_enroll:
+${_("To start accessing course materials, please visit {course_url}").format(
+		course_url=course_url
+	)}
+% elif course_about_url is not None:
+${_("Visit {course_about_url} to join the course and begin the beta test.").format(course_about_url=course_about_url)}
+% else:
+${_("Visit {site_name} to enroll in the course and begin the beta test.").format(site_name=site_name)}
+% endif
+</p>
+<p>
+<hr />
+${_("This email was automatically sent from {site_name} to "
+	"{email_address}").format(
+		site_name=site_name, email_address=email_address
+	)}
+</p>
+</%block>

--- a/lms/templates/emails/business_order_confirmation_email.html
+++ b/lms/templates/emails/business_order_confirmation_email.html
@@ -1,0 +1,106 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+<%block name="message">
+<p>
+${_("Hi {name},").format(name=recipient_name)}
+</p>
+<p>
+${_("Thank you for your purchase of ")} <b> ${course_names} </b>
+</p>
+%if recipient_type == 'user':
+<p>${_("Your payment was successful.")}</p>
+% if marketing_link('FAQ'):
+<p>${_("If you have billing questions, please read the FAQ ({faq_url}) or contact {billing_email}.").format(billing_email=payment_support_email, faq_url=marketing_link('FAQ'))}</p>
+% else:
+<p>${_("If you have billing questions, please contact {billing_email}.").format(billing_email=payment_support_email)}</p>
+% endif
+
+%elif recipient_type == 'company_contact':
+
+<p>${_("{order_placed_by} placed an order and mentioned your name as the Organization contact.").format(order_placed_by=order_placed_by)}</p>
+
+%elif recipient_type == 'email_recipient':
+
+<p>${_("{order_placed_by} placed an order and mentioned your name as the additional receipt recipient.").format(order_placed_by=order_placed_by)}</p>
+
+%endif
+
+<p>${_("The items in your order are:")}</p>
+
+<p>${_("Quantity - Description - Price")}<br>
+%for order_item in order_items:
+    ${order_item.qty} - ${order_item.line_desc} - ${currency_symbol}${order_item.line_cost}</p>
+%endfor
+
+<p>${_("Total billed to credit/debit card: {currency_symbol}{total_cost}").format(total_cost=order.total_cost, currency_symbol=currency_symbol)}</p>
+
+<p>
+% if order.company_name:
+${_('Company Name:')} ${order.company_name}<br>
+%endif
+% if order.customer_reference_number:
+${_('Purchase Order Number:')} ${order.customer_reference_number}<br>
+%endif
+% if order.company_contact_name:
+${_('Company Contact Name:')} ${order.company_contact_name}<br>
+ %endif
+% if order.company_contact_email:
+${_('Company Contact Email:')} ${order.company_contact_email}<br>
+%endif
+% if order.recipient_name:
+## Translators: this will be the name of a person receiving an email
+${_('Recipient Name:')} ${order.recipient_name}<br>
+ %endif
+% if order.recipient_email:
+## Translators: this will be the email address of a person receiving an email
+${_('Recipient Email:')} ${order.recipient_email}<br>
+ %endif
+
+% if has_billing_info:
+${order.bill_to_cardtype} ${_("#:")} ${order.bill_to_ccnum}<br>
+${order.bill_to_first} ${order.bill_to_last}<br>
+${order.bill_to_street1}<br>
+${order.bill_to_street2}<br>
+${order.bill_to_city}, ${order.bill_to_state} ${order.bill_to_postalcode}<br>
+${order.bill_to_country.upper()}
+% endif
+</p>
+<p>${_("Order Number: {order_number}").format(order_number=order.id)}</p>
+
+<p><b>${_("A CSV file of your registration URLs is attached. Please distribute registration URLs to each student planning to enroll using the email template below.")}</b></p>
+
+% if payment_email_signature:
+## Translators: This is followed by the instructor or course team name (so could be singular or plural)
+<p>${_("Warm regards,")}<br>
+${payment_email_signature}
+% else:
+## Translators: The <br> is a line break (empty line), please keep this html in the string after the sign off.
+<p>${_("Warm regards,<br>"
+"The {platform_name} Team").format(platform_name=platform_name)}
+%endif
+</p>
+
+
+———————————————————————————————————————————
+
+
+## Translators: please translate the text inside [[ ]]. This is meant as a template for course teams to use.
+<p>${_("Dear [[Name]]")}</p>
+
+<p>${_("To enroll in {course_names} we have provided a registration URL for you.  Please follow the instructions below to claim your access.").format(course_names=course_names)}</p>
+
+## Translators: please translate the text inside [[ ]]. This is meant as a template for course teams to use.
+<p>${_("Your redeem url is: [[Enter Redeem URL here from the attached CSV]]")}</p>
+
+<p>${_("(1) Register for an account at {site_name}").format(site_name=u"<a href='https://{sn}'>https://{sn}</a>".format(sn=site_name))}<br>
+${_("(2) Once registered, copy the redeem URL and paste it in your web browser.")}<br>
+${_("(3) On the enrollment confirmation page, Click the 'Activate Enrollment Code' button. This will show the enrollment confirmation.")}<br>
+${_("(4) You should be able to click on 'view course' button or see your course on your student dashboard at {url}").format(
+	 url=u"<a href='https://{dashboard_url}'>https://{dashboard_url}</a>".format(dashboard_url=dashboard_url)
+)}<br>
+${_("(5) Course materials will not be available until the course start date.")}</p>
+
+## Translators: please translate the text inside [[ ]]. This is meant as a template for course teams to use. Please also keep the <p> and </p> HTML tags in place.
+${_("<p>Sincerely,</p>"
+"<p>[[Your Signature]]</p>")}
+</%block>

--- a/lms/templates/emails/confirm_email_change.html
+++ b/lms/templates/emails/confirm_email_change.html
@@ -1,0 +1,28 @@
+<%inherit file="main.html" />
+<%! from django.core.urlresolvers import reverse %>
+<%! from django.utils.translation import ugettext as _ %>
+<%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
+
+<%block name="message">
+<p>
+${_("This is to confirm that you changed the e-mail associated with "
+  "{platform_name} from {old_email} to {new_email}. If you "
+  "did not make this request, please contact us immediately. Contact "
+  "information is listed at:").format(
+      platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+      old_email=old_email,
+      new_email=new_email
+  )
+}
+</p>
+<pre>
+% if is_secure:
+    https://${ site }${reverse('contact')}
+% else:
+    http://${ site }${reverse('contact')}
+% endif
+</pre>
+<p>
+${_("We keep a log of old e-mails, so if this request was unintentional, we can investigate.")}
+</p>
+</%block>

--- a/lms/templates/emails/email_change.html
+++ b/lms/templates/emails/email_change.html
@@ -1,0 +1,29 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+<%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
+<%block name="message">
+<p>
+${_("We received a request to change the e-mail associated with your "
+    "{platform_name} account from {old_email} to {new_email}. "
+    "If this is correct, please confirm your new e-mail address by "
+    "visiting:").format(
+        platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+        old_email=old_email,
+        new_email=new_email
+    )
+}
+</p>
+<pre>
+% if is_secure:
+ https://${ site }/email_confirm/${ key }
+% else:
+ http://${ site }/email_confirm/${ key }
+% endif
+</pre>
+<p>
+${_("If you didn't request this, you don't need to do anything; you won't "
+  "receive any more email from us. Please do not reply to this e-mail; "
+  "if you require assistance, check the help section of the "
+  "{platform_name} web site.").format(platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME))}
+</p>
+</%block>

--- a/lms/templates/emails/enroll_email_allowedmessage.html
+++ b/lms/templates/emails/enroll_email_allowedmessage.html
@@ -1,0 +1,54 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Dear student,")}
+</p>
+<p>
+${_("You have been invited to join {course_name} at {site_name} by a "
+	"member of the course staff.").format(
+		course_name=display_name or course.display_name_with_default_escaped,
+		site_name=site_name
+	)}
+</p>
+<p>
+% if is_shib_course:
+% if auto_enroll:
+
+${_("To access the course visit {course_url} and login.").format(course_url=course_url)}
+% elif course_about_url is not None:
+
+${_("To access the course visit {course_about_url} and register for the course.").format(
+		course_about_url=course_about_url)}
+% endif
+% else:
+
+${_("To finish your registration, please visit {registration_url} and fill "
+	"out the registration form making sure to use {email_address} in the E-mail field.").format(
+		registration_url=registration_url,
+		email_address=email_address
+	)}
+<p>
+% if auto_enroll:
+${_("Once you have registered and activated your account, you will see "
+	"{course_name} listed on your dashboard.").format(
+		course_name=display_name or course.display_name_with_default_escaped
+	)}
+% elif course_about_url is not None:
+${_("Once you have registered and activated your account, visit {course_about_url} "
+	"to join the course.").format(course_about_url=course_about_url)}
+% else:
+${_("You can then enroll in {course_name}.").format(course_name=display_name or course.display_name_with_default_escaped)}
+% endif
+</p>
+% endif
+</p>
+<p>
+<hr />
+${_("This email was automatically sent from {site_name} to "
+	"{email_address}").format(
+		site_name=site_name, email_address=email_address
+	)}
+</p>
+</%block>

--- a/lms/templates/emails/enroll_email_enrolledmessage.html
+++ b/lms/templates/emails/enroll_email_enrolledmessage.html
@@ -1,0 +1,28 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Dear {full_name}").format(full_name=full_name)}
+</p>
+<p>
+${_("You have been enrolled in {course_name} at {site_name} by a member "
+	"of the course staff. The course should now appear on your {site_name} "
+	"dashboard.").format(
+		course_name=display_name or course.display_name_with_default_escaped,
+		site_name=site_name
+	)}
+</p>
+<p>
+${_("To start accessing course materials, please visit {course_url}").format(
+		course_url=course_url
+	)}
+</p>
+<p>
+<hr />
+${_("This email was automatically sent from {site_name} to "
+	"{full_name}").format(
+		site_name=site_name, full_name=full_name
+	)}
+</p>
+</%block>

--- a/lms/templates/emails/main.html
+++ b/lms/templates/emails/main.html
@@ -1,0 +1,3 @@
+<!-- {% block message %} -->
+<%block name="message"></%block>
+<!-- {% endblock %} -->

--- a/lms/templates/emails/order_confirmation_email.html
+++ b/lms/templates/emails/order_confirmation_email.html
@@ -1,0 +1,51 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Hi {name},").format(name=order.user.profile.name)}
+</p>
+<p>
+${_("Your payment was successful. You will see the charge below on your next credit or debit card statement under the company name {merchant_name}.").format(merchant_name=settings.CC_MERCHANT_NAME)}
+</p>
+<p>
+% if marketing_link('FAQ'):
+${_("If you have billing questions, please read the FAQ ({faq_url}) or contact {billing_email}.").format(billing_email=payment_support_email, faq_url=marketing_link('FAQ'))}
+% else:
+${_("If you have billing questions, please contact {billing_email}.").format(billing_email=payment_support_email)}
+% endif
+</p>
+<p>
+${_("Thank you,")}
+% if payment_email_signature:
+${payment_email_signature}
+% else:
+${_("The {platform_name} Team").format(platform_name=platform_name)}
+% endif
+</p>
+<pre>
+${_("Your order number is: {order_number}").format(order_number=order.id)}
+
+${_("The items in your order are:")}
+
+${_("Quantity - Description - Price")}
+% for order_item in order_items:
+    ${order_item.qty} - ${order_item.line_desc} - ${currency_symbol}${order_item.line_cost}
+% endfor
+
+${_("Total billed to credit/debit card: {currency_symbol}{total_cost}").format(total_cost=order.total_cost, currency_symbol=currency_symbol)}
+
+% if has_billing_info:
+${order.bill_to_cardtype} ${_("#:")} ${order.bill_to_ccnum}
+${order.bill_to_first} ${order.bill_to_last}
+${order.bill_to_street1}
+${order.bill_to_street2}
+${order.bill_to_city}, ${order.bill_to_state} ${order.bill_to_postalcode}
+${order.bill_to_country.upper()}
+% endif
+
+% for order_item in order_items:
+${order_item.additional_instruction_text()}
+% endfor
+</pre>
+</%block>

--- a/lms/templates/emails/photo_submission_confirmation.html
+++ b/lms/templates/emails/photo_submission_confirmation.html
@@ -1,0 +1,19 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Hi {full_name},").format(full_name=full_name)}
+</p>
+<p>
+${_("Thanks for submitting your photos!")}
+</p>
+<p>
+${_("We've received your information and the verification process has begun. You can check the status of the verification process on your dashboard.")}
+</p>
+<p>
+${_("Thank you,")}
+
+${_("The {platform_name} team").format(platform_name=platform_name)}
+</p>
+</%block>

--- a/lms/templates/emails/registration_codes_sale_email.html
+++ b/lms/templates/emails/registration_codes_sale_email.html
@@ -1,0 +1,42 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Thank you for purchasing enrollments in {course_name}.").format(course_name=course.display_name)}
+</p>
+<p>
+${_("An invoice for {currency_symbol}{total_price} is attached. Payment is due upon receipt. You can find information about payment methods on the invoice.").format(currency_symbol=currency_symbol, total_price=sale_price)}
+</p>
+<p>
+${_("A .csv file that lists your enrollment codes is attached. You can use the email template below to distribute enrollment codes to your students. Each student must use a separate enrollment code.")}
+</p>
+<p>
+## Translators: This is the signature of an email.  "\n" is a newline character
+## and should be placed between the closing word and the signature.
+${_("Thanks,\nThe {platform_name} Team").format(platform_name=platform_name)}
+</p>
+
+<p>
+<hr />
+
+## Translators: please translate the text inside [[ ]]. This is meant as a template for course teams to use.
+${_("Dear [[Name]]:")}
+</p>
+<p>
+## Translators: please translate the text inside [[ ]]. This is meant as a template for course teams to use.
+${_("We have provided a course enrollment code for you in {course_name}. To enroll in the course, click the following link:").format(course_name=course.display_name)}
+</p>
+<p>
+[[${_("HTML link from the attached CSV file")}]]
+</p>
+<p>
+${_("After you enroll, you can see the course on your student dashboard. You can see course materials after the course start date.")}
+</p>
+<p>
+## Translators: please translate the text inside [[ ]]. This is meant as a template for course teams to use.
+## This is the signature of an email.  "\n" is a newline character
+## and should be placed between the closing word and the signature.
+${_("Sincerely,\n[[Your Signature]]")}
+</p>
+</%block>

--- a/lms/templates/emails/remove_beta_tester_email_message.html
+++ b/lms/templates/emails/remove_beta_tester_email_message.html
@@ -1,0 +1,26 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Dear {full_name}").format(full_name=full_name)}
+</p>
+<p>
+${_("You have been removed as a beta tester for {course_name} at {site_name} by a "
+	"member of the course staff. The course will remain on your dashboard, but "
+	"you will no longer be part of the beta testing group.").format(
+		course_name=course.display_name_with_default_escaped,
+		site_name=site_name
+	)}
+</p>
+<p>
+${_("Your other courses have not been affected.")}
+</p>
+<p>
+<hr />
+${_("This email was automatically sent from {site_name} to "
+	"{email_address}").format(
+		site_name=site_name, email_address=email_address
+	)}
+</p>
+</%block>

--- a/lms/templates/emails/unenroll_email_allowedmessage.html
+++ b/lms/templates/emails/unenroll_email_allowedmessage.html
@@ -1,0 +1,21 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<h1>HTML</h1>
+<p>
+${_("Dear Student,")}
+</p>
+<p>
+${_("You have been un-enrolled from course {course_name} by a member "
+    "of the course staff. Please disregard the invitation "
+    "previously sent.").format(course_name=display_name or course.display_name_with_default_escaped)}
+</p>
+<p>
+<hr />
+${_("This email was automatically sent from {site_name} "
+	"to {email_address}").format(
+		site_name=site_name, email_address=email_address
+	)}
+</p>
+</%block>

--- a/lms/templates/emails/unenroll_email_enrolledmessage.html
+++ b/lms/templates/emails/unenroll_email_enrolledmessage.html
@@ -1,0 +1,25 @@
+<%inherit file="main.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="message">
+<p>
+${_("Dear {full_name}").format(full_name=full_name)}
+</p>
+<p>
+${_("You have been un-enrolled in {course_name} at {site_name} by a member "
+    "of the course staff. The course will no longer appear on your "
+    "{site_name} dashboard.").format(
+        course_name=display_name or course.display_name_with_default_escaped, site_name=site_name
+    )}
+</p>
+<p>
+${_("Your other courses have not been affected.")}
+</p>
+<p>
+<hr />
+${_("This email was automatically sent from {site_name} to "
+    "{full_name}").format(
+        full_name=full_name, site_name=site_name
+    )}
+</p>
+</%block>


### PR DESCRIPTION
**Description:** html versions of email templates added for branding purpose. Emails are partially tested. For example was taken ficus platform commit resolving this problem (https://github.com/raccoongang/edx-platform/commit/99e0c71434a7977a0edef783a75b6bd4e628cb14)

**Youtrack:** https://youtrack.raccoongang.com/issue/FLS-17

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

