### PR TITLE
[ACCEL] integrate course_date_offsets transformer to the lms transformers

### DIFF
--- a/lms/djangoapps/course_blocks/api.py
+++ b/lms/djangoapps/course_blocks/api.py
@@ -7,10 +7,14 @@ from django.conf import settings
 from openedx.core.djangoapps.content.block_structure.api import get_block_structure_manager
 from openedx.core.djangoapps.content.block_structure.transformers import BlockStructureTransformers
 
-from .transformers import library_content, start_date, user_partitions, visibility, load_override_data
+from .transformers import library_content, user_partitions, visibility, load_override_data
 from .usage_info import CourseUsageInfo
 
-from rg_odoo_api.transformers import user_partitions_date_modificator
+# course_date_offsets is transformer that enable work with disable Subsection content
+# for which due date is out for special cohort which we setup.
+# It is installable plugin which locate in gitlab repository by url
+# https://gitlab.raccoongang.com/hippoteam/edx/course_date_offsets
+from course_date_offsets.transformers import user_partitions_date_modificator
 
 INDIVIDUAL_STUDENT_OVERRIDE_PROVIDER = 'courseware.student_field_overrides.IndividualStudentOverrideProvider'
 
@@ -30,7 +34,6 @@ def get_course_block_access_transformers():
     """
     course_block_access_transformers = [
         library_content.ContentLibraryTransformer(),
-        # start_date.StartDateTransformer(),
         user_partitions_date_modificator.UserDatePartitionTransformer(),
         user_partitions.UserPartitionTransformer(),
         visibility.VisibilityTransformer(),

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -151,3 +151,6 @@ zendesk                             # Python API for the Zendesk customer suppor
 
  # Accel customization
 -e git+ssh://git@gitlab.raccoongang.com/rg-developers/rg-odoo-edx-api.git@added_sso#egg=rg-odoo-api==0.0.1
+
+# Course date offsets transformer
+-e git+ssh://git@gitlab.raccoongang.com/hippoteam/edx/course_date_offsets.git@release-0.0.1#egg=course_date_offsets

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -264,3 +264,6 @@ django-hvad==1.8.0
 # Accel customization
 -e git+ssh://git@gitlab.raccoongang.com/rg-developers/rg-odoo-edx-api.git@release-0.0.1#egg=rg-odoo-api==0.0.1
 -e git+ssh://git@gitlab.raccoongang.com/hippoteam/accel/edx-plugin-for-odoos-chat.git@release-0.1#egg=edx-plugin-for-odoos-chat==0.1
+
+# Course date offsets transformer
+-e git+ssh://git@gitlab.raccoongang.com/hippoteam/edx/course_date_offsets.git@release-0.0.1#egg=course_date_offsets


### PR DESCRIPTION
**Description:** changes import rg_odoo_api to course_date_offsets. This action needs for exclude offset transformer functionality from rg_odoo_api to course_date_offsets plugin

**Youtrack:** [ticket](https://youtrack.raccoongang.com/issue/ACCEL-290), [review ticket](https://youtrack.raccoongang.com/issue/ACCEL-482)