### PR TITLE
Fix bug with schedule parameters for RG Analytics

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1111,3 +1111,6 @@ if AUTH_TOKENS.get('RG_SENTRY_DSN', None):
 # Variable for overriding standard MKTG_URLS
 EXTERNAL_MKTG_URLS = ENV_TOKENS.get('EXTERNAL_MKTG_URLS', {})
 #RACCOONGANG
+
+# Get Schedule parameters for RG Analytics
+RG_ANALYTICS_GRADE_STAT_UPDATE = ENV_TOKENS.get('RG_ANALYTICS_GRADE_STAT_UPDATE', {})


### PR DESCRIPTION
**Description:**
Celery beat execute grade_collector_stat() only with defaults parameters (every 6 hours)

**Youtrack:**
https://youtrack.raccoongang.com/issue/RGA2-87

**Testing instructions:**
Look at  /edx/var/log/supervisor/celerybeat-stderr.log
Task : Scheduler: Sending due task rg_instructor_analytics.tasks.grade_collector_stat (rg_instructor_analytics.tasks.grade_collector_stat)

Should be executed according to you schedule settings in lms.env.json

**Related Confluence documents:**
- https://raccoongang.atlassian.net/wiki/spaces/tech/pages/1237057564/RG+Analytics+2.0+installation+manual
