### PR TITLE
HBI-304: ORA2 default storage settings added to the production settings

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -593,6 +593,8 @@ if AUTH_TOKENS.get('RG_SENTRY_DSN', None):
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     sentry_sdk.init(AUTH_TOKENS.get('RG_SENTRY_DSN'), integrations=[DjangoIntegration()])
+
+ORA2_FILEUPLOAD_BACKEND = ENV_TOKENS.get("ORA2_FILEUPLOAD_BACKEND", "django")
 #RACCOONGANG
 
 ####################### Plugin Settings ##########################

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1108,6 +1108,7 @@ if AUTH_TOKENS.get('RG_SENTRY_DSN', None):
     from sentry_sdk.integrations.django import DjangoIntegration
     sentry_sdk.init(AUTH_TOKENS.get('RG_SENTRY_DSN'), integrations=[DjangoIntegration()])
 
+ORA2_FILEUPLOAD_BACKEND = ENV_TOKENS.get("ORA2_FILEUPLOAD_BACKEND", "django")
 # Variable for overriding standard MKTG_URLS
 EXTERNAL_MKTG_URLS = ENV_TOKENS.get('EXTERNAL_MKTG_URLS', {})
 #RACCOONGANG

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -25,7 +25,7 @@ git+https://github.com/mitodl/edx-sga.git@6b2f7aa2a18206023c8407e2c46f86d4b4c3ac
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
+git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -28,7 +28,7 @@ git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
+git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -89,7 +89,7 @@
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
+-e git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
 -e git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -26,7 +26,7 @@ git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
+git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev


### PR DESCRIPTION
**Description:** ORA2 default storage settings added to the production settings
This fixes the situation when ORA2 is trying to find an S3 Bucket configuration to store the assessments there. Now they will be stored at the django storage by default.

**Youtrack:** https://youtrack.raccoongang.com/issue/HBI-304

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Related Confluence documents:**
- < URL to Confluence document 1 >
- < URL to Confluence document 2 >
- ...
- < URL to Confluence document N >

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation in source code updated
- [ ] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
