### PR TITLE
[FLANE] Lakeside email fix for unenrolling by staff

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -179,11 +179,14 @@ def unenroll_email(course_id, student_email, email_students=False, email_params=
     previous_state = EmailEnrollmentState(course_id, student_email)
     if previous_state.enrollment:
         CourseEnrollment.unenroll_by_email(student_email, course_id)
+        CourseEnrollmentAllowed.objects.get(course_id=course_id, email=student_email).delete()
         if email_students:
             email_params['message'] = 'enrolled_unenroll'
             email_params['email_address'] = student_email
             email_params['full_name'] = previous_state.full_name
             send_mail_to_student(student_email, email_params, language=language)
+
+    previous_state = EmailEnrollmentState(course_id, student_email)
 
     if previous_state.allowed:
         CourseEnrollmentAllowed.objects.get(course_id=course_id, email=student_email).delete()

--- a/lms/templates/emails/unenroll_email_allowedmessage.html
+++ b/lms/templates/emails/unenroll_email_allowedmessage.html
@@ -2,7 +2,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <%block name="message">
-<h1>HTML</h1>
 <p>
 ${_("Dear Student,")}
 </p>


### PR DESCRIPTION
**Description:**  PROBLEM: The user registered by a staff invitation receives two different unenrollment emails if a staff unenrolls the user from a course. The user registered by a staff invitation receives two different unenrollment emails if a staff unenrolls the user from a course. 
SOLUTION: unenroll email sending logic changed - if student was unenrolled by stuff member his "allowed" status removes and only one email will be send (about unenrollment).

**Youtrack:** https://youtrack.raccoongang.com/issue/FLS-47


**Testing instructions:**

1) log in to LMS as a staff
2) open the Instructor tab of a course
3) in the Instructor tab, open the Membership section
4) in the Batch Enrollment form, fill in the Email and Reason fields with a valid data
5) click the Enroll button
6) log out as a staff
7) go https://lms-lakeside-stage.raccoongang.com/register
8) fill in the registration form with valid data, use the email from Step 4
9) in the received Activation email, use the activation link to activate your account
10) log out as a student
11) log in to LMS as a staff
12) open the Instructor tab of the course
13) in the Instructor tab, open the Membership section
14) in the Batch Enrollment form, fill in the Email and Reason fields with valid data, use the email from Step 4
15) click the Unenroll button
16) check the mailbox

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** Unenroll email sending was checked for hawthorn and ironwood platforms and standart logic is the same - student receives two emails (1. that he was unenrolled, 2. the he was unenrolled and should disregard the invitation previously sent) 
