### PR TITLE
HBI-304: html5lib update required by ORA2

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -28,7 +28,7 @@
 analytics-python==1.1.0             # Used for Segment analytics
 attrs                               # Reduces boilerplate code involving class attributes
 Babel==1.3                          # Internationalization utilities, used for date formatting in a few places
-bleach==1.4                         # Allowed-list-based HTML sanitizing library that escapes or strips markup and attributes; used for capa and LTI
+bleach==2.0                         # Allowed-list-based HTML sanitizing library that escapes or strips markup and attributes; used for capa and LTI
 boto==2.39.0                        # Deprecated version of the AWS SDK; we should stop using this
 boto3==1.4.8                        # Amazon Web Services SDK for Python
 botocore==1.8.17                    # via boto3, s3transfer
@@ -94,7 +94,7 @@ futures ; python_version == "2.7"   # via django-pipeline, python-swift-client, 
 glob2==0.3                          # Enhanced glob module, used in openedx.core.lib.rooted_paths
 gunicorn==0.17.4
 help-tokens
-html5lib==0.999                     # HTML parser, used for capa problems
+html5lib==1.0.1                     # HTML parser, used for capa problems
 ipaddr==2.1.11                      # Ip network support for Embargo feature
 jsonfield                           # Django model field for validated JSON; used in several apps
 mailsnake==1.6.2                    # Needed for mailchimp (mailing djangoapp)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -71,7 +71,7 @@ attrs==17.4.0
 babel==1.3
 beautifulsoup==3.2.1      # via pynliner
 billiard==3.3.0.23        # via celery
-bleach==1.4
+bleach==2.0
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -160,7 +160,7 @@ glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1          # via django-memcached-hashring
 help-tokens==1.0.3
-html5lib==0.999
+html5lib==1.0.1
 httplib2==0.11.3          # via oauth2, zendesk
 idna==2.7
 ipaddr==2.1.11

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -64,7 +64,7 @@ beautifulsoup4==4.6.0
 beautifulsoup==3.2.1
 before-after==1.0.1
 billiard==3.3.0.23
-bleach==1.4
+bleach==2.0
 bok-choy==0.7.3
 boto3==1.4.8
 boto==2.39.0
@@ -177,7 +177,7 @@ glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1
 help-tokens==1.0.3
-html5lib==0.999
+html5lib==1.0.1
 httplib2==0.11.3
 httpretty==0.9.5
 idna==2.7

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -61,7 +61,7 @@ beautifulsoup4==4.6.0
 beautifulsoup==3.2.1
 before-after==1.0.1
 billiard==3.3.0.23
-bleach==1.4
+bleach==2.0
 bok-choy==0.7.3
 boto3==1.4.8
 boto==2.39.0
@@ -170,7 +170,7 @@ glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1
 help-tokens==1.0.3
-html5lib==0.999
+html5lib==1.0.1
 httplib2==0.11.3
 httpretty==0.9.5
 idna==2.7


### PR DESCRIPTION
**Description:** Previous pull request has triggered the requirements conflict:
New ORA2 requires html5lib==1.0.1, but `hawthorn-rg` branch contains the html5lib==0.999 in requirements.
Update to the 1.0.1 of `html5lib` triggered the update of the `bleach` to the version 2.0

**Youtrack:** https://youtrack.raccoongang.com/issue/HBI-304

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Related Confluence documents:**
- < URL to Confluence document 1 >
- < URL to Confluence document 2 >
- ...
- < URL to Confluence document N >

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation in source code updated
- [ ] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
