### PR TITLE
HBI-304: Revert because of versions conflicts

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -593,8 +593,6 @@ if AUTH_TOKENS.get('RG_SENTRY_DSN', None):
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     sentry_sdk.init(AUTH_TOKENS.get('RG_SENTRY_DSN'), integrations=[DjangoIntegration()])
-
-ORA2_FILEUPLOAD_BACKEND = ENV_TOKENS.get("ORA2_FILEUPLOAD_BACKEND", "django")
 #RACCOONGANG
 
 ####################### Plugin Settings ##########################

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1108,7 +1108,6 @@ if AUTH_TOKENS.get('RG_SENTRY_DSN', None):
     from sentry_sdk.integrations.django import DjangoIntegration
     sentry_sdk.init(AUTH_TOKENS.get('RG_SENTRY_DSN'), integrations=[DjangoIntegration()])
 
-ORA2_FILEUPLOAD_BACKEND = ENV_TOKENS.get("ORA2_FILEUPLOAD_BACKEND", "django")
 # Variable for overriding standard MKTG_URLS
 EXTERNAL_MKTG_URLS = ENV_TOKENS.get('EXTERNAL_MKTG_URLS', {})
 #RACCOONGANG

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -28,7 +28,7 @@
 analytics-python==1.1.0             # Used for Segment analytics
 attrs                               # Reduces boilerplate code involving class attributes
 Babel==1.3                          # Internationalization utilities, used for date formatting in a few places
-bleach==2.0                         # Allowed-list-based HTML sanitizing library that escapes or strips markup and attributes; used for capa and LTI
+bleach==1.4                         # Allowed-list-based HTML sanitizing library that escapes or strips markup and attributes; used for capa and LTI
 boto==2.39.0                        # Deprecated version of the AWS SDK; we should stop using this
 boto3==1.4.8                        # Amazon Web Services SDK for Python
 botocore==1.8.17                    # via boto3, s3transfer
@@ -94,7 +94,7 @@ futures ; python_version == "2.7"   # via django-pipeline, python-swift-client, 
 glob2==0.3                          # Enhanced glob module, used in openedx.core.lib.rooted_paths
 gunicorn==0.17.4
 help-tokens
-html5lib==1.0.1                     # HTML parser, used for capa problems
+html5lib==0.999                     # HTML parser, used for capa problems
 ipaddr==2.1.11                      # Ip network support for Embargo feature
 jsonfield                           # Django model field for validated JSON; used in several apps
 mailsnake==1.6.2                    # Needed for mailchimp (mailing djangoapp)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -25,7 +25,7 @@ git+https://github.com/mitodl/edx-sga.git@6b2f7aa2a18206023c8407e2c46f86d4b4c3ac
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
+git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -71,7 +71,7 @@ attrs==17.4.0
 babel==1.3
 beautifulsoup==3.2.1      # via pynliner
 billiard==3.3.0.23        # via celery
-bleach==2.0
+bleach==1.4
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -160,7 +160,7 @@ glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1          # via django-memcached-hashring
 help-tokens==1.0.3
-html5lib==1.0.1
+html5lib==0.999
 httplib2==0.11.3          # via oauth2, zendesk
 idna==2.7
 ipaddr==2.1.11

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -64,7 +64,7 @@ beautifulsoup4==4.6.0
 beautifulsoup==3.2.1
 before-after==1.0.1
 billiard==3.3.0.23
-bleach==2.0
+bleach==1.4
 bok-choy==0.7.3
 boto3==1.4.8
 boto==2.39.0
@@ -177,7 +177,7 @@ glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1
 help-tokens==1.0.3
-html5lib==1.0.1
+html5lib==0.999
 httplib2==0.11.3
 httpretty==0.9.5
 idna==2.7

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -28,7 +28,7 @@ git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
+git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -89,7 +89,7 @@
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
+-e git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -61,7 +61,7 @@ beautifulsoup4==4.6.0
 beautifulsoup==3.2.1
 before-after==1.0.1
 billiard==3.3.0.23
-bleach==2.0
+bleach==1.4
 bok-choy==0.7.3
 boto3==1.4.8
 boto==2.39.0
@@ -170,7 +170,7 @@ glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1
 help-tokens==1.0.3
-html5lib==1.0.1
+html5lib==0.999
 httplib2==0.11.3
 httpretty==0.9.5
 idna==2.7

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -26,7 +26,7 @@ git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
+git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev


### PR DESCRIPTION
**Description:** Reverting the ORA2 version update because it was resulted in at least two requirements conflict (one of them was not easy to track and caught only on the stage server).

**Youtrack:** https://youtrack.raccoongang.com/issue/HBI-304