### PR TITLE
ACCEL-538: Explicity adds app label for CohortAssigment model.

### DIFF
--- a/lms/djangoapps/instructor/models.py
+++ b/lms/djangoapps/instructor/models.py
@@ -1,8 +1,9 @@
 """
 Module for instructor models.
 """
-from django.db import models
 from django.contrib.auth.models import User
+from django.db import models
+
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 
 
@@ -12,3 +13,7 @@ class CohortAssigment(models.Model):
     """
     user = models.ForeignKey(User, db_index=True, on_delete=models.CASCADE)
     cohort = models.ForeignKey(CourseUserGroup, db_index=True, on_delete=models.CASCADE)
+
+    class Meta:
+        app_label = 'instructor'
+        managed = True


### PR DESCRIPTION
**Description:** In the studio, when switching to a specific course, the server crashes with a 500 error. It crashes because it cannot explicitly determine which application the `CohortAssigment` model belongs to. To solve this problem, I had to explicitly indicate for the `CohortAssigment `model which application it belongs to. Hope this works. Locally it worked.

**Youtrack:** https://youtrack.raccoongang.com/issue/ACCEL-538

**Post merge:**
- [+] Delete working branch (if not needed anymore)
