### PR TITLE
[LAKESIDE] Fix for 500 when deteting category without courses

### DIFF
--- a/common/djangoapps/course_category/models.py
+++ b/common/djangoapps/course_category/models.py
@@ -71,17 +71,17 @@ def delete_reindex_course_category(sender, instance, **kwargs):
     category_courses = instance.courses.all()
     if category_courses:
         instance.courses_list = map(lambda x: str(x.id), category_courses)
-    elif instance.courses_list:
+    elif getattr(instance, 'courses_list', []):
         task_reindex_courses.delay(course_keys=instance.courses_list)
-
 
 @receiver(m2m_changed, sender=CourseCategory.courses.through)
 def save_reindex_course_category(sender, instance, pk_set, action, **kwargs):
     courses_set = set()
     if action == 'pre_remove':
         instance.pre_clear_course_keys = set()
-        instance.pre_clear_course_keys.update(instance.courses.all().values_list('id', flat=True))
+        instance.pre_clear_course_keys.update(str(x.id) for x in instance.courses.all())
+
     if action in ['post_add', 'post_remove']:
-        courses_set.update(instance.courses.all().values_list('id', flat=True))
+        courses_set.update(str(x.id) for x in instance.courses.all())
         courses_set.update(getattr(instance, 'pre_clear_course_keys', set()))
         task_reindex_courses.delay(instance.id, list(courses_set))

--- a/common/djangoapps/course_category/tasks.py
+++ b/common/djangoapps/course_category/tasks.py
@@ -15,8 +15,8 @@ def task_reindex_courses(category_id=None, course_keys=None):
             courses.update(category.courses.all().values_list('id', flat=True))
             courses.update(category.get_descendants().values_list('courses', flat=True))
     for course_key in courses:
+        course_key = CourseKey.from_string(course_key)
         CoursewareSearchIndexer.do_course_reindex(modulestore(), course_key)
-
 
 @task
 def task_add_categories(category_names, course_id):


### PR DESCRIPTION
elastic fix for course reindex when category deletes

**Description:** Fixing logic for reindexing courses in elastic

**Youtrack:** https://youtrack.raccoongang.com/issue/FLS-73

**Testing instructions:**
1) log in https://localhost:18000/admin
2) go https://localhost:18000/admin/course_category/coursecategory/
3) click the 'Add course category' button
4) in the Category Name field, input a category name (for example, Test)
5) click the Save button
6) in the list of categories, click Edit to edit the category
7) click the Delete button
8) in the 'Are you sure?' dialog, click the 'Yes, I'm sure' button

ER: Category must be successfully deleted


**Post merge:**
- [ ] Delete working branch (if not needed anymore)


