### PR TITLE
[LAKESIDE] bugfix FLS-82

### DIFF
--- a/common/djangoapps/course_category/tasks.py
+++ b/common/djangoapps/course_category/tasks.py
@@ -6,6 +6,14 @@ from xmodule.modulestore.django import modulestore
 
 @task
 def task_reindex_courses(category_id=None, course_keys=None):
+    """
+    Reindex courses while saving changes in category
+
+        Args:
+            category_id: int
+            course_keys: set of CourseLocators
+
+    """
     from course_category.models import CourseCategory
     from cms.djangoapps.contentstore.courseware_index import CoursewareSearchIndexer
     courses = set(course_keys) if course_keys else set()
@@ -15,7 +23,6 @@ def task_reindex_courses(category_id=None, course_keys=None):
             courses.update(category.courses.all().values_list('id', flat=True))
             courses.update(category.get_descendants().values_list('courses', flat=True))
     for course_key in courses:
-        course_key = CourseKey.from_string(course_key)
         CoursewareSearchIndexer.do_course_reindex(modulestore(), course_key)
 
 @task


### PR DESCRIPTION
**Description:** Elastic fix - course_id (str) changed to CourseLocator
search_engine fix (AttributeError: 'NoneType' object has no attribute 'keys' ) - search engine called while saving changes to category had different 'results' dict then when searching courses

**Youtrack:** https://youtrack.raccoongang.com/issue/FLS-82

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** I decided to return previous logic in reindex tasks because it seems to be more 
logical (without double conversions)