### PR TITLE
SU-139 Redirect and buttons in header

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -57,7 +57,7 @@ def index(request):
         if configuration_helpers.get_value(
                 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER',
                 settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
-            return redirect(reverse('dashboard'))
+            return redirect(reverse('course_category_list'))
 
     if settings.FEATURES.get('AUTH_USE_CERTIFICATES'):
         from openedx.core.djangoapps.external_auth.views import ssl_login

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -373,6 +373,12 @@ FEATURES = {
 
 COURSE_DISCOVERY_FILTERS = ["org", "language", "modes", "category"]
 
+COURSE_DISCOVERY_MEANINGS = {
+    'category': {
+        'name': 'Topics',
+    }
+}
+
 COURSE_DISCOVERY_FACETS = {
     'category': {
         'size': 100

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -183,7 +183,7 @@ COURSE_DISCOVERY_MEANINGS = {
     },
     'language': LANGUAGE_MAP,
     'category': {
-        'name': 'Categories',
+        'name': 'Topics',
     }
 }
 


### PR DESCRIPTION
[SU-139](https://youtrack.raccoongang.com/issue/SU-139) Redirect and buttons in header
- re-configure redirect for the logged user. Once user logged in he has to reach Explore Categories page, not Dashboard