### PR TITLE
[LAKESIDE] Unerllolment email fix FLS-84

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -179,16 +179,20 @@ def unenroll_email(course_id, student_email, email_students=False, email_params=
     previous_state = EmailEnrollmentState(course_id, student_email)
     if previous_state.enrollment:
         CourseEnrollment.unenroll_by_email(student_email, course_id)
-        CourseEnrollmentAllowed.objects.get(course_id=course_id, email=student_email).delete()
+        # To avoid sending two emails (enrolled_unenroll and allowed_unenroll):
+        if previous_state.allowed:
+            CourseEnrollmentAllowed.objects.get(course_id=course_id, email=student_email).delete()
         if email_students:
             email_params['message'] = 'enrolled_unenroll'
             email_params['email_address'] = student_email
             email_params['full_name'] = previous_state.full_name
             send_mail_to_student(student_email, email_params, language=language)
 
-    previous_state = EmailEnrollmentState(course_id, student_email)
+    # Its not valid to change previous_state itself, it will cause invalid message
+    # in instructor dashboard after sending email
+    previous_state_update = EmailEnrollmentState(course_id, student_email)
 
-    if previous_state.allowed:
+    if previous_state_update.allowed:
         CourseEnrollmentAllowed.objects.get(course_id=course_id, email=student_email).delete()
         if email_students:
             email_params['message'] = 'allowed_unenroll'


### PR DESCRIPTION
**Description:** In the Membership section of the Instructor
Dashboard, if an instructor unenrolls a student,
 the error message is displayed (fixed), the
student does not receive unenrollment email(fixed).

**Youtrack:** https://youtrack.raccoongang.com/issue/FLS-84

**Configuration instructions:** Email backend configured (if testing locally).

**Testing instructions:**

PRECONDITIONS:
activated student account;
activated course instructor account;
test course;

STR:
1) log in as a course instructor https://lms-lakeside-stage.raccoongang.com/login
2) open the Membership section of the Instructor Dashboard
3) in the Batch Enrollment form, input the student account email and the reason
4) click the Enroll button
(after Step 4 the student becomes enrolled and receives the enrollment email)
5) in the Batch Enrollment form, input the student account email and the reason
6) click the Unenroll button

ER:
no error message
the student has received the unenrollment email
the student has been unenrolled

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


