### PR TITLE
UCDC-72: Dependency location fix.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -268,7 +268,7 @@ pip==9.0.1
 django-mptt-admin==0.4.2
 
 # UCDC integration. Plugin that describes the REST-full api through which UCDC portal interacts with the EDX platform.
--e common/lib/ucdc_edx_api_plugin
+-e lms/lib/ucdc_edx_api_plugin
 
 # UCDC SSO and API integration
 git+https://github.com/raccoongang/edx-oauth-client.git@ucdc-v.0.1.0#egg=edx_oauth_client==ucdc-v.0.1.0

--- a/requirements/edx/local.in
+++ b/requirements/edx/local.in
@@ -12,4 +12,4 @@
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 
 # UCDC integration. Plugin that describes the REST-full api through which UCDC portal interacts with the EDX platform.
--e common/lib/ucdc_edx_api_plugin
+-e lms/lib/ucdc_edx_api_plugin


### PR DESCRIPTION
**Description:** During refactoring the task of creating a plug-in for API integration with UCDC, the place for its storage was changed. In the dependencies, I forgot to fix the path.
PR evaporate my mistake.

**Youtrack:** https://youtrack.raccoongang.com/issue/UCDC-72
