### PR TITLE
Remove server rendering of dynamic parts of the index page.

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -188,19 +188,9 @@ def index(request, extra_context=None, user=AnonymousUser()):
     # Add marketable programs to the context.
     context['programs_list'] = get_programs_with_type(request.site, include_hidden=False)
 
-    if configuration_helpers.get_value(
-            "ENABLE_COURSE_SORTING_BY_START_DATE",
-            settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"],
-    ):
-        courses_sorter = sort_by_start_date
-    else:
-        courses_sorter = sort_by_announcement
+    context['programs'] = []
 
-    programs = group_courses_by_program(get_courses(user), courses_sorter, get_programs(request.site))
-    context['programs'] = programs
-    context['categories'] = CourseCategory.objects.filter(parent=None)
-
-    context['courses'] = get_courses(user)
+    context['courses'] = []
     context['course_discovery_meanings'] = getattr(settings, 'COURSE_DISCOVERY_MEANINGS', {})
 
     return render_to_response('index.html', context)


### PR DESCRIPTION
**Description:**
Since server rendering data is not always actual, it causes flickering of programs & courses on index page. Removing any data makes page load smoother, since programs & courses/products' data is anyways request and loaded on page load.

**Youtrack:** https://youtrack.raccoongang.com/issue/FLS-127
