### PR TITLE
FLS-101 Microsite registration page is used instead of the main site registration page.

### DIFF
--- a/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
+++ b/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
@@ -46,7 +47,8 @@ class Command(BaseCommand):
         programs = {}
         for site in Site.objects.all():
             site_config = getattr(site, 'configuration', None)
-            if site_config is None or not site_config.get_value('COURSE_CATALOG_API_URL'):
+            if site_config is None or not site_config.get_value('COURSE_CATALOG_API_URL',
+                                                                settings.COURSE_CATALOG_API_URL):
                 logger.info('Skipping site {domain}. No configuration.'.format(domain=site.domain))
                 cache.set(SITE_PROGRAM_UUIDS_CACHE_KEY_TPL.format(domain=site.domain), [], None)
                 continue

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -31,7 +31,7 @@ def create_catalog_api_client(user, site=None):
     jwt = JwtBuilder(user).build_token(scopes, expires_in)
 
     if site:
-        url = site.configuration.get_value('COURSE_CATALOG_API_URL')
+        url = site.configuration.get_value('COURSE_CATALOG_API_URL', settings.COURSE_CATALOG_API_URL)
     else:
         url = CatalogIntegration.current().get_internal_api_url()
 


### PR DESCRIPTION
- [FLS-100](https://youtrack.raccoongang.com/issue/FLS-100) Microsite login page is used instead of the main site login page.
- [FLS-101](https://youtrack.raccoongang.com/issue/FLS-101) Microsite registration page is used instead of the main site registration page.

To use the home page of the site registration and login, you must disable the site configuration. Therefore, you need to specify the correct `COURSE_CATALOG_API_URL` in the settings, for cache_programs to work correctly