### PR TITLE
[LAKESIDE] Fix for cache_programs command when site configurations wa…

### DIFF
--- a/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
+++ b/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
@@ -52,8 +52,12 @@ class Command(BaseCommand):
                     logger.info('Skipping site {domain}. No configuration.'.format(domain=site.domain))
                     cache.set(SITE_PROGRAM_UUIDS_CACHE_KEY_TPL.format(domain=site.domain), [], None)
                     continue
+                else:
+                    course_catalog_api_url = settings.COURSE_CATALOG_API_URL
+            else:
+                course_catalog_api_url = site_config.get_value('COURSE_CATALOG_API_URL')
 
-            client = create_catalog_api_client(user, site=site)
+            client = create_catalog_api_client(user, course_catalog_api_url)
             uuids, program_uuids_failed = self.get_site_program_uuids(client, site)
             new_programs, program_details_failed = self.fetch_program_details(client, uuids)
 

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -24,18 +24,16 @@ from student.models import CourseEnrollment
 logger = logging.getLogger(__name__)
 
 
-def create_catalog_api_client(user, site=None):
+def create_catalog_api_client(user, course_catalog_api_url=None):
     """Returns an API client which can be used to make Catalog API requests."""
     scopes = ['email', 'profile']
     expires_in = settings.OAUTH_ID_TOKEN_EXPIRATION
     jwt = JwtBuilder(user).build_token(scopes, expires_in)
 
-    if site:
-        url = site.configuration.get_value('COURSE_CATALOG_API_URL', settings.COURSE_CATALOG_API_URL)
-    else:
-        url = CatalogIntegration.current().get_internal_api_url()
+    if not course_catalog_api_url:
+        course_catalog_api_url = CatalogIntegration.current().get_internal_api_url()
 
-    return EdxRestApiClient(url, jwt=jwt)
+    return EdxRestApiClient(course_catalog_api_url, jwt=jwt)
 
 
 def get_programs(site, uuid=None):


### PR DESCRIPTION
…s deleted.

**Description:** In case when site configuration was deleted (or not exists at all) it will raise error: django.db.models.fields.related_descriptors.RelatedObjectDoesNotExist: Site has no configuration.
So additional check was added.

**Youtrack:** https://youtrack.raccoongang.com/issue/FLS-169

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

