### PR TITLE
SKILLONOMY-159: Display the wallets form for non-staff users

### DIFF
--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -124,7 +124,7 @@ def learner_profile_context(request, profile_username, user_is_staff):
         },
         'disable_courseware_js': True,
         # Skillonomy customization
-        "display_wallets_data": user_is_staff and own_profile and settings.FEATURES["DISPLAY_WALLETS"],
+        "display_wallets_data": own_profile and settings.FEATURES["DISPLAY_WALLETS"],
     }
 
     if badges_enabled():


### PR DESCRIPTION
**Description:** 

Need to display the wallets form for non-staff users (remove redundant `user_is_staff ` check)

**Youtrack:**

https://youtrack.raccoongang.com/issue/SKILLONOMY-159
