### PR TITLE
HERA-152 - [Development] [LMS part] XBlock (hera-pages).

### DIFF
--- a/hera_xblocks/hera_pages/hera_pages/hera_pages.py
+++ b/hera_xblocks/hera_pages/hera_pages/hera_pages.py
@@ -63,8 +63,9 @@ class HeraPagesXBlock(StudioEditableXBlockMixin, XBlock):
         frag.add_css_url("https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.css")
         frag.add_css_url("https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick-theme.css")
         
-        frag.add_javascript_url("https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.css")
         frag.add_javascript_url("https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.js")
         
+        frag.add_javascript_url("https://cdn.jsdelivr.net/gh/vast-engineering/jquery-popup-overlay@2/jquery.popupoverlay.min.js")
+      
         frag.initialize_js('HeraPagesXBlock')
         return frag

--- a/hera_xblocks/hera_pages/hera_pages/static/css/hera_pages.css
+++ b/hera_xblocks/hera_pages/hera_pages/static/css/hera_pages.css
@@ -23,7 +23,29 @@
     /* float:left; */
     width:600px;
 }
+
 .column {
     float: left;
     width: 33%;
 }
+
+.popup_content {
+    margin: 10px;
+    padding: 0 10px;
+    max-width: 60%;
+    border: 2px solid #444;
+    background: white;
+  }
+  
+  .instructor-info-action {
+      visibility: hidden;
+  }
+  
+  .bookmark-button {
+    visibility: hidden;
+  }
+  
+.slick-arrow {
+    visibility: hidden;
+}
+  

--- a/hera_xblocks/hera_pages/hera_pages/static/html/hera_pages.html
+++ b/hera_xblocks/hera_pages/hera_pages/static/html/hera_pages.html
@@ -1,5 +1,5 @@
 <div class="hera_pages_block">
-    <div class="wrapper-page">
+    <div class="wrapper-page" id="wrapper-page">
         <div class="image-wrapper">
         {% if data.imgUrl %}
             <img src="{{ data.imgUrl }}" alt=""/>
@@ -22,3 +22,8 @@
 </div>
 
 
+<section id="slider-popup">
+    <p>Give it another try.
+    <br />
+    If you'd like to exit the simulation instead, click exit.</p>
+</section>

--- a/hera_xblocks/hera_pages/hera_pages/static/js/src/hera_pages.js
+++ b/hera_xblocks/hera_pages/hera_pages/static/js/src/hera_pages.js
@@ -1,7 +1,7 @@
 /* Javascript for HeraPagesXBlock. */
 function HeraPagesXBlock(runtime, element) {
     var isFormValid;
-    
+    $('#slider-popup').popup();
     $('.slidebar-wrapper').slick({
         slidesToShow: 1,
         slidesToScroll: 1,
@@ -20,7 +20,7 @@ function HeraPagesXBlock(runtime, element) {
     $(".button-next").click((e) => {
         if(shouldShowMessage && !isFormValid()) {
             shouldShowMessage = false;
-            alert('Fill up al the fields');
+            $('#slider-popup').popup('show')
         } else {
             $(".slick-next").trigger("click")
         }


### PR DESCRIPTION
HERA-152 - [Development] [LMS part] XBlock (hera-pages). Content Displaying.

**Description:** HERA-152 - [Development] [LMS part] XBlock (hera-pages). Content Displaying.
          - adds the jquery pop up if the user does not fill up the fields
	 - hides the buttons on jquery slick.
	 - hides the instructor info action fields.

**Youtrack:**[HERA-152](https://youtrack.raccoongang.com/issue/HERA-152)

**Reviewers:**
- [ ] @sendr 
- [ ] @UvgenGen 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation in source code updated
- [ ] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

