### PR TITLE
Change the billing information source for PayPal

### DIFF
--- a/lms/djangoapps/shoppingcart/processors/PayPal.py
+++ b/lms/djangoapps/shoppingcart/processors/PayPal.py
@@ -107,7 +107,8 @@ def _record_purchase(params, order):
     # Mark the order as purchased and store the billing information
     payer = params.get('payer', {})
     payer_info = payer.get('payer_info', {})
-    billing_address = payer_info.get('billing_address', {})
+    # Data was formerly present under 'billing_address', but now it seems to be at 'shipping_address'
+    billing_address = payer_info.get('billing_address') or payer_info.get('shipping_address', {})
     order.purchase(
         first=payer_info.get('first_name', ''),
         last=payer_info.get('last_name', ''),


### PR DESCRIPTION
**Description:**
- Previously the billing information for the payment
  was provided under the 'billing_address' but now
  it is under the 'shipping_address' key
- Update code to try to get info from the 'billing_address'
  and in case of failure grab the 'shipping_address' one

**Youtrack:** 
https://youtrack.raccoongang.com/issue/FLS-212
