### PR TITLE
[HERA-354] Remove 'Delete' button from onboarding edit page

### DIFF
--- a/lms/djangoapps/hera/admin.py
+++ b/lms/djangoapps/hera/admin.py
@@ -48,6 +48,12 @@ class OnboardingAdmin(admin.ModelAdmin):
         """
         return not self.model.objects.exists()
 
+    def has_delete_permission(self, request, obj=None):
+        """
+        Forbid to delete onboarding item(s).
+        """
+        return False
+
     def get_actions(self, request):
         """
         Remove all actions by returning an empty dictionary.


### PR DESCRIPTION
[HERA-354](https://youtrack.raccoongang.com/issue/HERA-354) Onboarding pages admin side [LMS]
- remove 'Delete' button from edit Onboarding page
