### PR TITLE
[LAKESIDE-212] Revert fix

### DIFF
--- a/lms/djangoapps/shoppingcart/processors/PayPal.py
+++ b/lms/djangoapps/shoppingcart/processors/PayPal.py
@@ -107,8 +107,7 @@ def _record_purchase(params, order):
     # Mark the order as purchased and store the billing information
     payer = params.get('payer', {})
     payer_info = payer.get('payer_info', {})
-    # Data was formerly present under 'billing_address', but now it seems to be at 'shipping_address'
-    billing_address = payer_info.get('billing_address') or payer_info.get('shipping_address', {})
+    billing_address = payer_info.get('billing_address', {})
     order.purchase(
         first=payer_info.get('first_name', ''),
         last=payer_info.get('last_name', ''),


### PR DESCRIPTION
**Description:**
Since billing address & shipping address aren't fundamentally the same billing address should not be obtained from the shipping address. Billing address is not being sent in sandbox environment.

**Youtrack:**
https://youtrack.raccoongang.com/issue/FLS-212