### PR TITLE
[ Profitonomy ] SKILLONOMY-210: Redirect to Auth0 login form directly, hide reg btn

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -211,7 +211,18 @@ def index(request, extra_context=None, user=AnonymousUser()):
 
     context['programs_list'] = get_programs_with_type(include_hidden=False)
 
+    if third_party_auth.is_enabled() and not request.user.is_authenticated():
+        context['tpa_hint'] = get_auth0_provider_id()
+
     return render_to_response('index.html', context)
+
+
+def get_auth0_provider_id():
+    """Get Auth0 provider id if enabled."""
+    for enabled in third_party_auth.provider.Registry.displayed_for_login():
+        if enabled.is_auth0():
+            return enabled.provider_id
+    log.info("Auth0 is not configured/enabled.")
 
 
 def process_survey_link(survey_link, user):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -211,18 +211,7 @@ def index(request, extra_context=None, user=AnonymousUser()):
 
     context['programs_list'] = get_programs_with_type(include_hidden=False)
 
-    if third_party_auth.is_enabled() and not request.user.is_authenticated():
-        context['tpa_hint'] = get_auth0_provider_id()
-
     return render_to_response('index.html', context)
-
-
-def get_auth0_provider_id():
-    """Get Auth0 provider id if enabled."""
-    for enabled in third_party_auth.provider.Registry.displayed_for_login():
-        if enabled.is_auth0():
-            return enabled.provider_id
-    log.info("Auth0 is not configured/enabled.")
 
 
 def process_survey_link(survey_link, user):

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -285,6 +285,10 @@ class ProviderConfig(ConfigurationModel):
         """Gets associated Django settings.AUTHENTICATION_BACKEND string."""
         return '{}.{}'.format(self.backend_class.__module__, self.backend_class.__name__)
 
+    def is_auth0(self):
+        """Define if it's an Auth0 provider we are working with."""
+        return self.backend_class.is_auth0()
+
     @property
     def display_for_login(self):
         """

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -77,6 +77,8 @@ def login_and_registration_form(request, initial_mode="login"):
     if '?' in redirect_to:
         try:
             next_args = urlparse.parse_qs(urlparse.urlparse(redirect_to).query)
+            if 'next' in next_args.keys():
+                next_args = urlparse.parse_qs(urlparse.urlparse(next_args['next'][0]).query)
             provider_id = next_args['tpa_hint'][0]
             tpa_hint_provider = third_party_auth.provider.Registry.get(provider_id=provider_id)
             if tpa_hint_provider:

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -551,7 +551,7 @@ def account_settings_context(request):
                 'options': all_languages(),
             }, 'time_zone': {
                 'options': TIME_ZONE_CHOICES,
-            }, 
+            },
             'mobytize_id': user.profile.mobytize_id,
             'mobytize_token': user.profile.mobytize_token,
         },

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -575,7 +575,10 @@ TEMPLATES = [
 
                 # Online contextual help
                 'help_tokens.context_processor',
-                'openedx.core.djangoapps.site_configuration.context_processors.configuration_context'
+                'openedx.core.djangoapps.site_configuration.context_processors.configuration_context',
+
+                # TPA configs
+                'openedx.core.djangoapps.external_auth.context_processors.tpa_hint_context',
             ],
             # Change 'debug' in your environment settings files - not here.
             'debug': False

--- a/openedx/core/djangoapps/external_auth/context_processors.py
+++ b/openedx/core/djangoapps/external_auth/context_processors.py
@@ -1,0 +1,27 @@
+"""
+Django template context processors.
+"""
+
+import third_party_auth
+
+
+def tpa_hint_context(request):
+    """
+    TPA hint context for django templates.
+    """
+    return {
+        'tpa_hint': get_auth0_provider_id() if hasattr(request, 'user') and not request.user.is_authenticated() else None
+    }
+
+
+def get_auth0_provider_id():
+    """
+    Get Auth0 provider id if configured and enabled.
+
+    Returns:
+        Auth0 provider id (str) or `None` if configuration is not enabled.
+    """
+    if third_party_auth.is_enabled():
+        for enabled in third_party_auth.provider.Registry.displayed_for_login():
+            if enabled.is_auth0():
+                return enabled.provider_id


### PR DESCRIPTION
**Description:** 

Redirect to Auth0 login form directly (skipping native edX login form), hide registration btn.

**Youtrack:**

https://youtrack.raccoongang.com/issue/SKILLONOMY-210

**Configuration instructions:** 

See https://youtrack.raccoongang.com/issue/SKILLONOMY-117

**Testing instructions:**

Prereqs:

- regular flow: Auth0 provider config is set up and enabled; Auth0 is a single SSO provider configured
- multiple Auth0 providers are enabled
- Auth0 is not enabled / not configured


Use Cases:

- Signin from the main page
- Signin from the courses list page
- Signin from the about-course page
- Signin upon enrollment to the course.
- Authenticated user: same pages (regression)

**Reviewers:**
- [x] @GlugovGrGlib 
- [x] @dyudyunov 
- [x] @drtwisted 

**Merge checklist:**
- [x] ~All~ Two reviewers approved
- [x] CI build is green
- [x] Documentation in source code updated
- [x] All related Confluence documentation is updated (including deployment documentation)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 

- accompanying PRs: https://github.com/raccoongang/edx-theme/pull/1874, https://github.com/raccoongang/social-core/pull/2
- tests have to be fixed! (they most probably break)
- used hinted tpa  https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_advanced_features.html#hinted-sign-in. Alternative: 
```
    redirect_to = get_next_url_for_login_page(request)
    if third_party_auth.is_enabled():
        for enabled in third_party_auth.provider.Registry.displayed_for_login():
            if enabled.backend_class.is_auth0():
                login_url = pipeline.get_login_url(
                    enabled.provider_id,
                    pipeline.AUTH_ENTRY_LOGIN,
                    redirect_url=redirect_to,
                )
                return redirect(login_url)
    log.info("Auth0 seems to not be configured.")
```