### PR TITLE
[SKILLONOMY-214] Add Course Partners section

### DIFF
--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -343,7 +343,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                     )}</span>
                 </li>
                 <li class="field text" id="field-course-overview-teacher">
-                  <label for="course-overview-teacher">${_("Course Teachers")}</label>
+                  <label for="course-overview-teacher">${_("Course Partners and Teachers")}</label>
                   <textarea class="tinymce text-editor" id="course-overview-teacher"></textarea>
                   <label class="sr" for="course-overview-cm-textarea">
                     ${_('HTML Code Editor')}

--- a/common/lib/xmodule/xmodule/templates/about/overview_teacher.yaml
+++ b/common/lib/xmodule/xmodule/templates/about/overview_teacher.yaml
@@ -3,6 +3,46 @@ metadata:
     display_name: overview_teacher
 
 data: |
+  <section class="partners-about course-page-section">
+    <h2 class="h2">Партнеры курса</h2>
+    <ul class="partners-about-list">
+      <li class="partners-about-list__item">
+        <a href="" class="partners-about-list__link" target="_blank">
+          <img src="http://placeimg.com/640/360/any" alt="">
+        </a>
+      </li>
+      <li class="partners-about-list__item">
+        <a href="" class="partners-about-list__link" target="_blank">
+          <img src="http://placeimg.com/1200/600/any" alt="">
+        </a>
+      </li>
+      <li class="partners-about-list__item">
+        <a href="" class="partners-about-list__link" target="_blank">
+          <img src="http://placeimg.com/140/60/any" alt="">
+        </a>
+      </li>
+      <li class="partners-about-list__item">
+        <a href="" class="partners-about-list__link" target="_blank">
+          <img src="http://placeimg.com/800/400/any" alt="">
+        </a>
+      </li>
+      <li class="partners-about-list__item">
+        <a href="" class="partners-about-list__link" target="_blank">
+          <img src="http://placeimg.com/768/380/any" alt="">
+        </a>
+      </li>
+      <li class="partners-about-list__item">
+        <a href="" class="partners-about-list__link" target="_blank">
+          <img src="http://placeimg.com/2000/1260/any" alt="">
+        </a>
+      </li>
+      <li class="partners-about-list__item">
+        <a href="" class="partners-about-list__link" target="_blank">
+          <img src="http://placeimg.com/150/150/any" alt="">
+        </a>
+      </li>
+    </ul>
+  </section>
   <section class="course-staff">
     <section class="course-teacher course-page-section">
     <h2 class="h2">Преподаватель курса</h2>


### PR DESCRIPTION
* Course Partners section added to `overview_teacher.yaml` template
* Changed lable for 'Course Teachers'
**Youtrack** https://youtrack.raccoongang.com/issue/SKILLONOMY-214
*Related to https://github.com/raccoongang/edx-theme/pull/1878 PR in `theme`*

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
