### PR TITLE
HERA-634 When user open scaffold w/o text and open scaffold w/o image , the "Show simulation" button doesn’t shown

### DIFF
--- a/hera_xblocks/question/question/static/js/src/question.js
+++ b/hera_xblocks/question/question/static/js/src/question.js
@@ -326,8 +326,6 @@ function QuestionXBlock(runtime, element, init_args) {
                         $closeBtn.removeClass("hidden");
                         hideSimulation();
                         hideSimulationButton();
-                    } else if (!isSimulationHiddenState) {
-                        showSimulation();
                     }
                     // do we need to rerender the content block
                     if (scaffoldContent.trim().length > 0) {


### PR DESCRIPTION
[HERA-634](https://youtrack.raccoongang.com/issue/HERA-634) When user open scaffold w/o text and open scaffold w/o image , the "Show simulation" button doesn’t shown