### PR TITLE
[LSE-241] added rg_instructor_analytics.urls

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -690,6 +690,18 @@ if settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE'):
             name='resubscribe_forum_update',
         ),
     )
+
+if settings.FEATURES.get('ENABLE_RG_INSTRUCTOR_ANALYTICS', False):
+    urlpatterns += (
+        url(
+            r'^courses/{}/tab/instructor_analytics/'.format(
+            settings.COURSE_ID_PATTERN,
+        ),
+        include('rg_instructor_analytics.urls'),
+        name='instructor_analytics_endpoint',
+        ),
+    )
+
 urlpatterns += (
     # This MUST be the last view in the courseware--it's a catch-all for custom tabs.
     url(


### PR DESCRIPTION
**Description:** Added rg_instructor_analytics.urls according to [documentation](https://raccoongang.atlassian.net/wiki/spaces/tech/pages/1237057564/RG+Analytics+installation)

**Youtrack:** https://youtrack.raccoongang.com/issue/LSE-241