### PR TITLE
[ ACT ] ACTEDU-570: hide student email on the progress page

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -61,7 +61,7 @@ username = get_enterprise_learner_generic_name(request) or student.username
                 </div>
                 % endif
                 <h2 class="hd hd-2 progress-certificates-title">
-                    ${_("Course Progress for Student '{username}' ({email})").format(username=username, email=student.email)}
+                    ${_("Course Progress for Student '{username}'").format(username=username)}
                 </h2>
 
                 <div class="wrapper-msg wrapper-auto-cert">


### PR DESCRIPTION
**Description:** Remove student email from the LMS Progress page

**Youtrack:** https://youtrack.raccoongang.com/issue/ACTEDU-570

**Merge deadline:** 21 April
