### PR TITLE
[TELESENS-106] Change contact link

### DIFF
--- a/lms/templates/emails/confirm_email_change.txt
+++ b/lms/templates/emails/confirm_email_change.txt
@@ -12,7 +12,9 @@ ${_("This is to confirm that you changed the e-mail associated with "
   )
 }
 
-% if settings.FEATURES['ENABLE_MKTG_SITE']:
+% if configuration_helpers.get_value('contacts_link_external'):
+    ${configuration_helpers.get_value('contacts_link_external')}
+% elif settings.FEATURES['ENABLE_MKTG_SITE']:
     ${marketing_link('CONTACT')}
 % else:
     % if is_secure:


### PR DESCRIPTION
Added possibility to set custom 'contact' link in site config
(use `contacts_link_external` key)

**Youtrack**
https://youtrack.raccoongang.com/issue/TSA-106

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

