### PR TITLE
T-318 Order of the Past fields

### DIFF
--- a/common/djangoapps/tedix_ro/views.py
+++ b/common/djangoapps/tedix_ro/views.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import time
 from csv import DictReader
 from urlparse import urljoin
 
@@ -102,34 +103,28 @@ def my_reports(request):
 
         due_date = due_date_datetime.date()
         today = utc_now.date()
+        date_data = time.mktime(date.timetuple())
         if today == due_date:
-            date_group = 'Today'
-            due_date_data.update({
-                'displayed_date': date_group,
-                'due_date_order': 1
-            })
+            displayed_date = date_group = 'Today'
+            due_date_order = 1
         elif (today - due_date).days == -1:
-            date_group = 'Tomorrow'
-            due_date_data.update({
-                'displayed_date': date_group,
-                'due_date_order': 2
-            })
+            displayed_date = date_group = 'Tomorrow'
+            due_date_order = 2
         elif (today - due_date).days < -1:
             date_group = 'Future'
-            due_date_data.update({
-                'displayed_date': '{}: {}'.format(date_group, date.strftime('%d %B')),
-                'due_date_order': 3
-            })
+            due_date_order = 3
+            displayed_date = '{}: {}'.format(date_group, date.strftime('%d %B'))
         elif (today - due_date).days > 0:
             date_group = 'Past'
-            due_date_data.update({
-                'displayed_date': '{}: {}'.format(date_group, date.strftime('%d %B')),
-                'due_date_order': 4
-            })
+            due_date_order = 4
+            displayed_date = '{}: {}'.format(date_group, date.strftime('%d %B'))
+            date_data *= -1
 
         due_date_data.update({
             'date_group': date_group.lower(),
-            'date_data': date.strftime('%Y-%m-%d')
+            'date_data': date_data,
+            'due_date_order': due_date_order,
+            'displayed_date' : displayed_date
         })
         return due_date_data
 


### PR DESCRIPTION
**Description:** 
_**Order of the Past fields**_
          added new logic of filtering data by js library dataTables.
	  If the due date in the past, filtering will passing by timestamps with value minus timestamp.
	  It was the easiest way to change the logic of filtering by the past date.

**Youtrack:** https://youtrack.raccoongang.com/issue/T-318

**Testing instructions:**

1. Create curses
2. assign students for courses
3. Test filters in the past

**Reviewers:**
- [ ] @sendr 
- [ ] @UvgenGen 


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation in source code updated
- [ ] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)