### PR TITLE
[FLS-365] Except integrity errors in get_or_create for allowedenrollment

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -151,9 +151,12 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
             email_params['full_name'] = previous_state.full_name
             send_mail_to_student(student_email, email_params, language=language)
     elif not is_email_retired(student_email):
-        cea, _ = CourseEnrollmentAllowed.objects.get_or_create(course_id=course_id, email=student_email)
-        cea.auto_enroll = auto_enroll
-        cea.save()
+        try:
+            cea, _ = CourseEnrollmentAllowed.objects.get_or_create(course_id=course_id, email=student_email)
+            cea.auto_enroll = auto_enroll
+            cea.save()
+        except IntegrityError as err:
+            log.error("Could not enroll the user %s in the course %s, because of the error: %s.", student_email, course_id, err)
         if email_students:
             email_params['message'] = 'allowed_enroll'
             email_params['email_address'] = student_email


### PR DESCRIPTION
**Description:** This is a workaround for sentry error https://sentry.raccoongang.com/organizations/duck-team/issues/13352/?project=22&query=is%3Aunresolved. The reason of this error is not clear.
**Youtrack:** https://youtrack.raccoongang.com/issue/FLS-365


**Post merge:**
- [ ] Delete working branch (if not needed anymore)
