### PR TITLE
[RYPE] Fix bulk email course link for microsites

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -103,7 +103,7 @@ def _get_course_email_context(course):
     course_end_date = get_default_time_display(course.end)
     course_root = reverse('course_root', kwargs={'course_id': course_id})
     course_url = '{}{}'.format(
-        settings.LMS_ROOT_URL,
+        configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
         course_root
     )
     image_url = u'{}{}'.format(settings.LMS_ROOT_URL, course_image_url(course))


### PR DESCRIPTION
**Description:** 
- Fix bulk email template context variable for microsite

**Youtrack:** 
[RTS-102](https://youtrack.raccoongang.com/issue/RTS-102)

**Configuration instructions:** 
- Add to each microsite settings (Configuration helpers) `LMS_ROOT_URL` which should be root path for microsite (ex. `https://micsoite.example.com`)

**Testing instructions:**
- [x] Demo was shown to QA

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
