### PR TITLE
T-398 Video results are duplicated  after second video view

### DIFF
--- a/common/djangoapps/tedix_ro/serializers.py
+++ b/common/djangoapps/tedix_ro/serializers.py
@@ -90,6 +90,8 @@ class VideoLessonSerializer(serializers.ModelSerializer):
                 Question.objects.get_or_create(
                     video_lesson=video_lesson,
                     question_id=question_id,
-                    attempt_count=attempt_count,
+                    defaults={
+                        'attempt_count': attempt_count,
+                    }
                 )
         return video_lesson


### PR DESCRIPTION
[T-398](https://youtrack.raccoongang.com/issue/T-398) Video results are duplicated  after second video view