### PR TITLE
[MAMAEdu-122845] Fix visibility by start date

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -195,6 +195,8 @@ def _can_access_descriptor_with_start_date(user, descriptor, course_key):  # pyl
         AccessResponse: The result of this access check. Possible results are
             ACCESS_GRANTED or a StartDateError.
     """
+    if settings.FEATURES.get('DISABLE_START_DATES_FOR_COURSE', False):
+        return ACCESS_GRANTED
     return check_start_date(user, descriptor.days_early_for_beta, descriptor.start, course_key)
 
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -88,7 +88,7 @@ from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG, course_home_url_name
 from openedx.features.course_experience.views.course_dates import CourseDatesFragmentView
-from openedx.features.course_experience.utils import get_course_outline_block_tree
+from openedx.features.course_experience.utils import get_course_outline_block_tree, get_flat_course_structure
 from openedx.features.enterprise_support.api import data_sharing_consent_required
 
 from shoppingcart.utils import is_shopping_cart_enabled
@@ -817,7 +817,8 @@ def course_about(request, course_id):
 
         certificate_data = certs_api.get_active_web_certificate(course)
 
-        course_block_tree = get_course_outline_block_tree(request, course_id)
+        course_structure = get_flat_course_structure(course_id)
+
         course_start_end_date = strftime_localized(course.start, "%d %B")
         if course.end:
             end_date = strftime_localized(course.end, "%d %B")
@@ -854,7 +855,7 @@ def course_about(request, course_id):
             'reviews_fragment_view': reviews_fragment_view,
             'certificate_data': certificate_data,
             'disable_window_wrap': True,
-            'blocks': course_block_tree,
+            'course_structure': course_structure,
             'duration': duration,
             'course_start_end_date': course_start_end_date,
         }

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -69,7 +69,8 @@ FEATURES = {
 
     ## DO NOT SET TO True IN THIS FILE
     ## Doing so will cause all courses to be released on production
-    'DISABLE_START_DATES': False,  # When True, all courses will be active, regardless of start date
+    'DISABLE_START_DATES': False,  # When True, all courses and other blocks will be active, regardless of start date
+    'DISABLE_START_DATES_FOR_COURSE': False,  # When True, all courses will be active, regardless of start date
 
     # for consistency in user-experience, keep the value of the following 3 settings
     # in sync with the corresponding ones in cms/envs/common.py

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -82,3 +82,31 @@ def get_course_outline_block_tree(request, course_id):
     mark_last_accessed(user, course_key, course_outline_root_block)
 
     return course_outline_root_block
+
+
+def get_flat_course_structure(course_id):
+    """
+    Get course structure directly from modulestore.
+
+    Args:
+        course_id (str): course id as a string
+
+    Returns:
+        List with dicts containing names of course sections and subsections
+    """
+    course_key = CourseKey.from_string(course_id)
+    root_block = modulestore().get_course(course_key)
+
+    course_structure = []
+    sections = root_block.get_children()
+
+    for section in sections:
+        subsections = section.get_children()
+        node = {section.display_name:[]}
+
+        for subsection in subsections:
+            node[section.display_name].append(subsection.display_name)
+
+        course_structure.append(node)
+
+    return course_structure


### PR DESCRIPTION
**Youtrack:**
https://youtrack.raccoongang.com/agiles/104-435/105-830?issue=MAMAEdu-122845

* discard changes from https://youtrack.raccoongang.com/issue/SKILLONOMY-104
(set `DISABLE_START_DATES` to False) - it caused unreleased blocks being visible
* add new setting `DISABLE_START_DATES_FOR_COURSE`
* add new function to get course structure directly from modulestore avoiding to use cache

**Relates to:**
*https://github.com/raccoongang/edx-theme/pull/2004*

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

