### PR TITLE
T-398 Video results are duplicated  after second video view

### DIFF
--- a/common/djangoapps/tedix_ro/serializers.py
+++ b/common/djangoapps/tedix_ro/serializers.py
@@ -86,12 +86,14 @@ class VideoLessonSerializer(serializers.ModelSerializer):
         for question_data in questions_answered:
             question_id = question_data.get('question_id')
             attempt_count = question_data.get('attempt_count')
-            if attempt_count: # don't create if it's 0
-                Question.objects.get_or_create(
-                    video_lesson=video_lesson,
-                    question_id=question_id,
-                    defaults={
-                        'attempt_count': attempt_count,
-                    }
-                )
+            question, created = Question.objects.get_or_create(
+                video_lesson=video_lesson,
+                question_id=question_id,
+                defaults={
+                    'attempt_count': attempt_count,
+                }
+            )
+            if not created and question.attempt_count == 0:
+                question.attempt_count = attempt_count
+                question.save()
         return video_lesson

--- a/common/djangoapps/tedix_ro/utils.py
+++ b/common/djangoapps/tedix_ro/utils.py
@@ -228,7 +228,8 @@ def encrypted_user_data(user):
     Return:
         Json object with the following data:
           - created (int): Timestamp user.date_joined.
-          - id (str): base64 encrypted username.
+          - id (str): md5 hashed username.
+          - usertype (str): "student"/"staff"/"null".
     """
     user_id = None
     created = None


### PR DESCRIPTION
[T-398](https://youtrack.raccoongang.com/issue/T-398) Video results are duplicated  after second video view
- fix video results in report after reassigning