### PR TITLE
[MAMAEdu-122877] Fix the custom sysadmin courses report

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin_get_course_users.py
+++ b/lms/djangoapps/dashboard/sysadmin_get_course_users.py
@@ -262,6 +262,7 @@ def get_report_data_for_course_users(courses, course_id):
 
         status_list = []
         # Need to go through parent-children structure again for catching html-only lessons
+        status = "-"
         for sequential in sequentials:
             for vertical in _get_children(sequential, course_ordered):
                 for unit in _get_children(vertical, course_ordered):


### PR DESCRIPTION
**Youtrack:** https://youtrack.raccoongang.com/issue/MAMAEdu-122877

The fix is pretty in line with what `_get_status()` does (if anything goes wrong, return `-`).
Checked on the devstack course with several enrolled users. The test course was imported from https://cms.mama-edu.com/export/course-v1:mama+cs6+2020 as stated in the ticket. The report generates fine.

**Reviewers:**
- [x] @GlugovGrGlib 
- [x] @dyudyunov 


**Author concerns:** Wasn't able to reproduce a bug on the devstack.