### PR TITLE
[MAMAEdu-122903] added specific version of 'django-classy-tags' module to requirements

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -33,6 +33,7 @@ django-oauth-toolkit==0.10.0
 django-pipeline-forgiving==1.0.0
 django-pyfs==1.0.6
 django-sekizai==0.8.2
+django-classy-tags==0.9.0
 django-ses==0.7.1
 django-simple-history==1.6.3
 django-statici18n==1.4.0


### PR DESCRIPTION
**Description:** Fix for broken course wiki

**Youtrack:** https://youtrack.raccoongang.com/issue/MAMAEdu-122903

```
Oct 14 13:23:16 courses [service_variant=lms][django.request][env:sandbox] ERROR [courses  14892] [base.py:256] - Internal Server Error: /courses/course-v1:WBA+wba2+sales/wiki/WBA.wba2.sales/
...
...
...
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 1159, in load
    lib = get_library(taglib)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/template/base.py", line 1394, in get_library
    lib = import_library(taglib_module)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/template/base.py", line 1333, in import_library
    mod = import_module(taglib_module)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/sekizai/templatetags/sekizai_tags.py", line 2, in <module>
    from classytags.core import Tag, Options
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/classytags/core.py", line 129, in <module>
    class Tag(TagMeta('TagMeta', (Node,), {})):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/classytags/core.py", line 117, in __new__
    return super().__new__(cls, name, bases, attrs)
TypeError: super() takes at least 1 argument (0 given)
```