### PR TITLE
Add default value if no HTTP_REFERER

### DIFF
--- a/openedx/core/djangoapps/user_api/permissions.py
+++ b/openedx/core/djangoapps/user_api/permissions.py
@@ -49,7 +49,7 @@ class CanRegisterAccount(permissions.IsAuthenticated):
     def has_permission(self, request, view):
         if request.method != 'POST':
             return True
-        if request.META.get('HTTP_REFERER').split('?')[0] == request.build_absolute_uri(reverse('register_user')):
+        if request.META.get('HTTP_REFERER', '').split('?')[0] == request.build_absolute_uri(reverse('register_user')):
             return True
         if third_party_auth.is_enabled():
             if third_party_auth.pipeline.running(request):


### PR DESCRIPTION
Fix AttributeError: 'NoneType' object has no attribute 'split' if no HTTP_REFERER