### PR TITLE
T-508 To delete non-existent Video lessons.

### DIFF
--- a/common/djangoapps/tedix_ro/admin.py
+++ b/common/djangoapps/tedix_ro/admin.py
@@ -97,8 +97,9 @@ class QuestionInline(admin.TabularInline):
 
 @admin.register(VideoLesson)
 class VideoLessonAdmin(admin.ModelAdmin):
-    list_display = ('user', 'course')
+    list_display = ('user', 'course', 'video_id')
     inlines = [QuestionInline]
+    search_fields = ['course', 'video_id', 'user__username']
 
 
 class ProfileForm(forms.ModelForm):


### PR DESCRIPTION
[T-508](https://youtrack.raccoongang.com/issue/T-508) - `To delete non-existent Video lessons.`
- add search_fields, list_display