### PR TITLE
[OP-276] Task. Add the ability to change the language in ecommerce

### DIFF
--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -77,13 +77,13 @@ class LanguagePreferenceMiddleware(object):
                 response.set_cookie(
                     settings.LANGUAGE_COOKIE,
                     value=user_pref,
-                    domain=settings.SESSION_COOKIE_DOMAIN,
+                    domain=configuration_helpers.get_value('SESSION_COOKIE_DOMAIN', settings.SESSION_COOKIE_DOMAIN),
                     max_age=COOKIE_DURATION,
                 )
             else:
                 response.delete_cookie(
                     settings.LANGUAGE_COOKIE,
-                    domain=settings.SESSION_COOKIE_DOMAIN
+                    domain=configuration_helpers.get_value('SESSION_COOKIE_DOMAIN', settings.SESSION_COOKIE_DOMAIN)
                 )
 
         return response

--- a/openedx/core/djangoapps/lang_pref/views.py
+++ b/openedx/core/djangoapps/lang_pref/views.py
@@ -10,6 +10,7 @@ from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from openedx.core.djangoapps.lang_pref import COOKIE_DURATION, LANGUAGE_KEY
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 @ensure_csrf_cookie
@@ -26,7 +27,7 @@ def update_session_language(request):
         response.set_cookie(
             settings.LANGUAGE_COOKIE,
             language,
-            domain=settings.SESSION_COOKIE_DOMAIN,
+            domain=configuration_helpers.get_value('SESSION_COOKIE_DOMAIN', settings.SESSION_COOKIE_DOMAIN),
             max_age=COOKIE_DURATION
         )
     return response


### PR DESCRIPTION
**Description:** The `SESSION_COOKIE_DOMAIN` value for `LANGUAGE_COOKIE` is taken from the site configuration.

**Youtrack:** https://youtrack.raccoongang.com/issue/OP-276

**Configuration instructions:** 
TODO

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer
TODO