### PR TITLE
[MAMAEdu-123073] - Archive and Online Courses tabs

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -672,7 +672,8 @@ def _remove_in_process_courses(courses_iter, in_process_course_actions):
             'rerun_link': _get_rerun_link_for_item(course.id),
             'org': course.display_org_with_default,
             'number': course.display_number_with_default,
-            'run': course.location.run
+            'run': course.location.run,
+            'archived': course.archived
         }
 
     in_process_action_course_keys = {uca.course_key for uca in in_process_course_actions}
@@ -869,6 +870,7 @@ def _rerun_course(request, org, number, run, fields):
 
     # Clear the fields that must be reset for the rerun
     fields['advertised_start'] = None
+    fields['archived'] = False
 
     # Rerun the course as a new celery task
     json_fields = json.dumps(fields, cls=EdxJSONEncoder)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -61,6 +61,7 @@ class CourseMetadata(object):
         'show_correctness',
         'chrome',
         'default_tab',
+        'archived',
     ]
 
     @classmethod

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -162,6 +162,7 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
                 e.preventDefault();
                 $('.courses-tab').toggleClass('active', tab === 'courses');
                 $('.libraries-tab').toggleClass('active', tab === 'libraries');
+                $('.archive-tab').toggleClass('active', tab === 'archive');
 
             // Also toggle this course-related notice shown below the course tab, if it is present:
                 $('.wrapper-creationrights').toggleClass('is-hidden', tab !== 'courses');
@@ -180,6 +181,7 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
 
             $('#course-index-tabs .courses-tab').bind('click', showTab('courses'));
             $('#course-index-tabs .libraries-tab').bind('click', showTab('libraries'));
+            $('#course-index-tabs .archive-tab').bind('click', showTab('archive'));
         };
 
         domReady(onReady);

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -32,7 +32,8 @@ define(['backbone', 'underscore', 'gettext', 'js/models/validation_helpers', 'js
                 entrance_exam_enabled: '',
                 entrance_exam_minimum_score_pct: '50',
                 learning_info: [],
-                instructor_info: {}
+                instructor_info: {},
+                archived: false,
             },
 
             validate: function(newattrs) {

--- a/cms/static/js/spec/views/pages/index_spec.js
+++ b/cms/static/js/spec/views/pages/index_spec.js
@@ -147,19 +147,28 @@ define(['jquery',
 
             it('can switch tabs', function() {
                 var $courses_tab = $('.courses-tab'),
-                    $libraraies_tab = $('.libraries-tab');
+                    $libraraies_tab = $('.libraries-tab'),
+                    $archive_tab = $('.archive_tab');
 
                 // precondition check - courses tab is loaded by default
                 expect($courses_tab).toHaveClass('active');
                 expect($libraraies_tab).not.toHaveClass('active');
+                expect($archive_tab).not.toHaveClass('active');
 
                 $('#course-index-tabs .libraries-tab').click();  // switching to library tab
                 expect($courses_tab).not.toHaveClass('active');
                 expect($libraraies_tab).toHaveClass('active');
+                expect($archive_tab).not.toHaveClass('active');
 
                 $('#course-index-tabs .courses-tab').click(); // switching to course tab
                 expect($courses_tab).toHaveClass('active');
                 expect($libraraies_tab).not.toHaveClass('active');
+                expect($archive_tab).not.toHaveClass('active');
+
+                $('#course-index-tabs .archive-tab').click(); // switching to archive tab
+                expect($archive_tab).toHaveClass('active');
+                expect($libraraies_tab).not.toHaveClass('active');
+                expect($courses_tab).not.toHaveClass('active');
             });
         });
     });

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -318,7 +318,7 @@
   }
 
   // ELEM: course listings
-  .courses-tab, .libraries-tab {
+  .courses-tab, .libraries-tab, .archive-tab {
     display: none;
 
     &.active {
@@ -326,7 +326,7 @@
     }
   }
 
-  .courses, .libraries {
+  .courses, .libraries , .archive {
     .title {
       @extend %t-title6;
       margin-bottom: $baseline;

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -338,16 +338,18 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 
       % if libraries_enabled:
       <ul id="course-index-tabs">
-        <li class="courses-tab active"><a>${_("Courses")}</a></li>
+        <li class="courses-tab active"><a>${_("Online Courses")}</a></li>
+        <li class="archive-tab"><a>${_("Archive")}</a></li>
         <li class="libraries-tab"><a>${_("Libraries")}</a></li>
       </ul>
       % endif
 
-      %if len(courses) > 0 or optimization_enabled:
+      %if (len(courses) > 0 or optimization_enabled) and (len(courses) != len([course_info for course_info in courses if course_info['archived'] == True])):
       <div class="courses courses-tab active">
         <ul class="list-courses">
           %for course_info in sorted(courses, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
-          <li class="course-item" data-course-key="${course_info['course_key']}">
+          % if course_info['archived'] == False:
+          <li id="course_key-${course_info['course_key']}" class="course-item" data-course-key="${course_info['course_key']}">
             <a class="course-link" href="${course_info['url']}">
               <h3 class="course-title">${course_info['display_name']}</h3>
 
@@ -372,10 +374,31 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
               </li>
               % endif
               <li class="action action-view">
-                <a href="${course_info['lms_link']}" rel="external" class="button view-button">${_("View Live")}</a>
+                <script>
+                  function changeArch(event) {
+                      var course_key = event.target.value
+                      console.log(course_key)
+                      var archived = JSON.stringify({"archived": true})
+
+                      var url = "http://localhost:9001/settings/details/".concat(course_key)
+                      $.ajax({
+                          url: url,
+                          type: "POST",
+                          data: archived,
+                          contentType: "application/json;",
+                          dataType: "json",
+                          success: function(res) {
+                              location.reload();
+                          }
+                      })
+
+                  }
+                </script>
+                <button id="Archive" value="${course_info['course_key']}" onclick="changeArch(event)" class="button view-button">${_("Move to archive")}</button>
               </li>
             </ul>
           </li>
+          %endif
           %endfor
         </ul>
       </div>
@@ -390,7 +413,12 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
             </div>
           </div>
         </div>
-
+        <script>
+        setTimeout(function() {
+          $('.courses-tab').removeClass("active");
+          $('.archive-tab').click();
+          }, 170);
+        </script>
         %if course_creator_status == "granted":
         <div class="notice-item has-actions">
           <div class="msg">
@@ -492,6 +520,74 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
             </dl>
           </div>
         </div>
+      </div>
+      % endif
+
+
+      %if len(courses) > 0 or optimization_enabled:
+      <div class="archive archive-tab">
+        <ul class="list-courses">
+          %for course_info in sorted(courses, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
+          % if course_info['archived'] == True:
+            <li class="course-item" data-course-key="${course_info['course_key']}">
+              <a class="course-link" href="${course_info['url']}">
+                <h3 class="course-title">${course_info['display_name']}</h3>
+
+                <div class="course-metadata">
+                  <span class="course-org metadata-item">
+                    <span class="label">${_("Organization:")}</span> <span class="value">${course_info['org']}</span>
+                  </span>
+                  <span class="course-num metadata-item">
+                    <span class="label">${_("Course Number:")}</span>
+                    <span class="value">${course_info['number']}</span>
+                  </span>
+                  <span class="course-run metadata-item">
+                    <span class="label">${_("Course Run:")}</span> <span class="value">${course_info['run']}</span>
+                  </span>
+                </div>
+              </a>
+
+              <ul  class="item-actions course-actions">
+                % if allow_course_reruns and rerun_creator_status and course_creator_status=='granted':
+                <li class="action action-rerun">
+                  <a href="${course_info['rerun_link']}" class="button rerun-button">${_("Re-run Course")}</a>
+                </li>
+                % endif
+              </ul>
+            </li>
+            %endif
+          %endfor
+        </ul>
+      </div>
+
+      %else:
+      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices courses-tab active">
+        <div class="notice-item">
+          <div class="msg">
+            <h3 class="title">${_("Are you staff on an existing {studio_name} course?").format(studio_name=settings.STUDIO_SHORT_NAME)}</h3>
+            <div class="copy">
+              <p>${_('The course creator must give you access to the course. Contact the course creator or administrator for the course you are helping to author.')}</p>
+            </div>
+          </div>
+        </div>
+
+        %if course_creator_status == "granted":
+        <div class="notice-item has-actions">
+          <div class="msg">
+            <h3 class="title">${_('Create Your First Course')}</h3>
+            <div class="copy">
+              <p>${_('Your new course is just a click away!')}</p>
+            </div>
+          </div>
+
+          <ul class="list-actions">
+            <li class="action-item">
+              <a href="#" class="action-primary action-create action-create-course new-course-button"><span class="icon fa fa-plus icon-inline" aria-hidden="true"></span> ${_('Create Your First Course')}</a>
+            </li>
+          </ul>
+        </div>
+        % endif
+
       </div>
       % endif
 

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -344,11 +344,11 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
       </ul>
       % endif
 
-      %if (len(courses) > 0 or optimization_enabled) and (len(courses) != len([course_info for course_info in courses if course_info['archived'] == True])):
+      %if (len(courses) > 0 or optimization_enabled) and (len(courses) != len([course_info for course_info in courses if course_info['archived']])):
       <div class="courses courses-tab active">
         <ul class="list-courses">
           %for course_info in sorted(courses, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
-          % if course_info['archived'] == False:
+          % if not course_info['archived']:
           <li id="course_key-${course_info['course_key']}" class="course-item" data-course-key="${course_info['course_key']}">
             <a class="course-link" href="${course_info['url']}">
               <h3 class="course-title">${course_info['display_name']}</h3>
@@ -368,7 +368,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
             </a>
 
             <ul  class="item-actions course-actions">
-              % if allow_course_reruns and rerun_creator_status and course_creator_status=='granted':
+              % if allow_course_reruns and rerun_creator_status and course_creator_status == 'granted':
               <li class="action action-rerun">
                 <a href="${course_info['rerun_link']}" class="button rerun-button">${_("Re-run Course")}</a>
               </li>
@@ -377,10 +377,9 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
                 <script>
                   function changeArch(event) {
                       var course_key = event.target.value
-                      console.log(course_key)
                       var archived = JSON.stringify({"archived": true})
 
-                      var url = "http://localhost:9001/settings/details/".concat(course_key)
+                      var url = "/settings/details/".concat(course_key)
                       $.ajax({
                           url: url,
                           type: "POST",

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -267,6 +267,8 @@ class CourseFields(object):
         scope=Scope.settings
     )
     end = Date(help=_("Date that this class ends"), scope=Scope.settings)
+    archived = Boolean(scope=Scope.settings, help=_('Enter "true" or "false". Enable/Disable feature'), default=False)
+
     certificate_available_date = Date(
         help=_("Date that certificates become available to learners"),
         scope=Scope.content
@@ -1469,9 +1471,10 @@ class CourseSummary(object):
     A lightweight course summary class, which constructs split/mongo course summary without loading
     the course. It is used at cms for listing courses to global staff user.
     """
-    course_info_fields = ['display_name', 'display_coursenumber', 'display_organization']
+    course_info_fields = ['display_name', 'display_coursenumber', 'display_organization', 'archived']
 
-    def __init__(self, course_locator, display_name=u"Empty", display_coursenumber=None, display_organization=None):
+    def __init__(self, course_locator, display_name=u"Empty", display_coursenumber=None, display_organization=None,
+                 archived=False):
         """
         Initialize and construct course summary
 
@@ -1487,11 +1490,13 @@ class CourseSummary(object):
         display_coursenumber (unicode|None): Course number that is specified & appears in the courseware
 
         display_organization (unicode|None): Course organization that is specified & appears in the courseware
+        archived: False
 
         """
         self.display_coursenumber = display_coursenumber
         self.display_organization = display_organization
         self.display_name = display_name
+        self.archived = archived
 
         self.id = course_locator  # pylint: disable=invalid-name
         self.location = course_locator.make_usage_key('course', 'course')

--- a/openedx/core/djangoapps/content/course_overviews/migrations/0019_courseoverview_archived.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0019_courseoverview_archived.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_overviews', '0018_courseoverview_telegram_chat_link'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseoverview',
+            name='archived',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -62,6 +62,7 @@ class CourseOverview(TimeStampedModel):
     end = DateTimeField(null=True)
     advertised_start = TextField(null=True)
     announcement = DateTimeField(null=True)
+    archived = BooleanField(default=False)
 
     # Skillonomy advanced settings
     price = TextField(default="Free")
@@ -174,6 +175,7 @@ class CourseOverview(TimeStampedModel):
         course_overview.end = end
         course_overview.advertised_start = course.advertised_start
         course_overview.announcement = course.announcement
+        course_overview.archived = course.archived
 
         course_overview.price = course.price
         course_overview.learning_format = course.learning_format

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -79,6 +79,7 @@ class CourseDetails(object):
         self.self_paced = None
         self.learning_info = []
         self.instructor_info = []
+        self.archived = False
 
     @classmethod
     def fetch_about_attribute(cls, course_key, attribute):
@@ -125,6 +126,7 @@ class CourseDetails(object):
         course_details.self_paced = course_descriptor.self_paced
         course_details.learning_info = course_descriptor.learning_info
         course_details.instructor_info = course_descriptor.instructor_info
+        course_details.archived = course_descriptor.archived
 
         # Default course license is "All Rights Reserved"
         course_details.license = getattr(course_descriptor, "license", "all-rights-reserved")
@@ -273,6 +275,10 @@ class CourseDetails(object):
             descriptor.language = jsondict['language']
             dirty = True
 
+        if 'archived' in jsondict:
+            descriptor.archived = jsondict['archived']
+            dirty = True
+
         if (SelfPacedConfiguration.current().enabled
                 and descriptor.can_toggle_course_pacing
                 and 'self_paced' in jsondict
@@ -295,8 +301,8 @@ class CourseDetails(object):
         for attribute in ABOUT_ATTRIBUTES:
             if attribute in jsondict:
                 cls.update_about_item(descriptor, attribute, jsondict[attribute], user.id)
-
-        cls.update_about_video(descriptor, jsondict['intro_video'], user.id)
+        if 'intro_video' in jsondict and jsondict['intro_video']:
+            cls.update_about_video(descriptor, jsondict['intro_video'], user.id)
 
         # Could just return jsondict w/o doing any db reads, but I put
         # the reads in as a means to confirm it persisted correctly


### PR DESCRIPTION
**AC:** 

- The new tabs are shown: "Online Courses" and "Archive";
- Button "Show course" doesn`t appear for all users;
- "Move to archive" button must be shown instead of "Show course";
- "Move to archive" button shown only for admin and staff roles;
- Course is moving to the archive by pressing "Move to archive" button;
- Must be able to re-run course from the archive(decided to provide re-run as recover option with @GlugovGrGlib );
- By default "Online courses" tab is active;
- If no courses in "Online courses" - "Archive" are shown;

**Youtrack:** https://youtrack.raccoongang.com/issue/MAMAEdu-123073



**Reviewers:**
- [ ] @GlugovGrGlib 
- [ ] @dyudyunov 
- [ ] @ViktorRusakov 


**Merge checklist:**
- [ ] All reviewers approved
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


