### PR TITLE
[BD-26] Add the is_proctored value to SequenceMetadata API

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -540,6 +540,7 @@ class SequenceBlock(
             'element_id': self.location.html_id(),
             'item_id': str(self.location),
             'is_time_limited': self.is_time_limited,
+            'is_proctored': self.is_proctored_enabled,
             'position': self.position,
             'tag': self.location.block_type,
             'next_url': context.get('next_url'),


### PR DESCRIPTION
**Description:** expand API `/api/courseware/sequence/` and add the `is_proctored` value. 

**Youtrack:** https://youtrack.raccoongang.com/issue/OeX_Proctoring-186
**Jira:** https://openedx.atlassian.net/browse/EDUCATOR-5799