### PR TITLE
[BD-26] Add 'allow_proctoring_opt_out' attribute for SequenceMetadata API

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -541,6 +541,7 @@ class SequenceBlock(
             'item_id': str(self.location),
             'is_time_limited': self.is_time_limited,
             'is_proctored': self.is_proctored_enabled,
+            'allow_proctoring_opt_out': self.allow_proctoring_opt_out,
             'position': self.position,
             'tag': self.location.block_type,
             'next_url': context.get('next_url'),


### PR DESCRIPTION
**Description:** Add 'allow_proctoring_opt_out' attribute for SequenceMetadata API

**Youtrack:** https://youtrack.raccoongang.com/issue/OeX_Proctoring-219
