### PR TITLE
[EDX_BLND_CLI-87] Update library content block to use v2 libs

### DIFF
--- a/xmodule/assets/library_content/public/js/library_content_edit_helpers.js
+++ b/xmodule/assets/library_content/public/js/library_content_edit_helpers.js
@@ -1,0 +1,60 @@
+/* JavaScript for special editing operations that can be done on LibraryContentXBlock */
+// This is a temporary UI improvements that will be removed when V2 content libraries became
+// fully functional
+
+/**
+ * Toggle the "Problem Type" settings section depending on selected library type.
+ * As for now, the V2 libraries don't support different problem types, so they can't be
+ * filtered by it. We're hiding the Problem Type field for them.
+ */
+function checkProblemTypeShouldBeVisible(editor) {
+    var libraries = editor.find('.wrapper-comp-settings.metadata_edit.is-active')
+        .data().metadata.source_library_id.options;
+    var selectedIndex = $("select[name='Library']", editor)[0].selectedIndex;
+    var libraryKey = libraries[selectedIndex].value;
+    var url = URI('/xblock')
+        .segment(editor.find('.xblock.xblock-studio_view.xblock-studio_view-library_content.xblock-initialized')
+        .data('usage-id'))
+        .segment('handler')
+        .segment('is_v2_library');
+
+    $.ajax({
+        type: 'POST',
+        url: url,
+        data: JSON.stringify({'library_key': libraryKey}),
+        success: function(data) {
+            var problemTypeSelect = editor.find("select[name='Problem Type']")
+                .parents("li.field.comp-setting-entry.metadata_entry");
+            data.is_v2 ? problemTypeSelect.hide() : problemTypeSelect.show();
+        }
+    });
+}
+
+var $librarySelect = $("select[name='Library']");
+
+$(document).on('change', $librarySelect, (e) => {
+    waitForEditorLoading();
+})
+
+$libraryContentEditors = $('.xblock-header.xblock-header-library_content');
+$editBtns = $libraryContentEditors.find('.action-item.action-edit');
+$(document).on('click', $editBtns, (e) => {
+    console.log('edit clicked')
+    waitForEditorLoading();
+})
+
+/**
+ * Waits untill editor html loaded, than calls checks for Program Type field toggling.
+ */
+function waitForEditorLoading() {
+    var checkContent = setInterval(function() {
+        $modal = $('.xblock-editor');
+        content = $modal.html();
+        if (content) {
+            clearInterval(checkContent);
+            checkProblemTypeShouldBeVisible($modal);
+        }
+    }, 10);
+}
+// Initial call
+waitForEditorLoading();

--- a/xmodule/library_content_module.py
+++ b/xmodule/library_content_module.py
@@ -460,6 +460,7 @@ class LibraryContentBlock(
         fragment = Fragment(
             self.runtime.service(self, 'mako').render_template(self.mako_template, self.get_context())
         )
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/library_content_edit_helpers.js'))
         add_webpack_to_fragment(fragment, 'LibraryContentBlockStudio')
         shim_xmodule_js(fragment, self.studio_js_module_name)
         return fragment
@@ -520,6 +521,22 @@ class LibraryContentBlock(
             return Response("Library Tools unavailable in current runtime.", status=400)
         self.tools.update_children(self, user_perms)
         return Response()
+
+    @XBlock.json_handler
+    def is_v2_library(self, data, suffix=''):  # lint-amnesty, pylint: disable=unused-argument
+        """
+        Check the library version by library_id.
+
+        This is a temporary handler needed for hiding the Problem Type xblock editor field for V2 libraries.
+        """
+        lib_key = data.get('library_key')
+        try:
+            LibraryLocatorV2.from_string(lib_key)
+        except InvalidKeyError:
+            is_v2 = False
+        else:
+            is_v2 = True
+        return {'is_v2': is_v2}
 
     # Copy over any overridden settings the course author may have applied to the blocks.
     def _copy_overrides(self, store, user_id, source, dest):

--- a/xmodule/library_content_module.py
+++ b/xmodule/library_content_module.py
@@ -8,37 +8,36 @@ import logging
 import random
 from copy import copy
 from gettext import ngettext
-from rest_framework import status
 
 import bleach
+from capa.responsetypes import registry
 from django.conf import settings
 from django.utils.functional import classproperty
 from lazy import lazy
 from lxml import etree
 from lxml.etree import XMLSyntaxError
-from opaque_keys.edx.locator import LibraryLocator
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.locator import LibraryLocator, LibraryLocatorV2
 from pkg_resources import resource_string
+from rest_framework import status
 from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
-from xblock.fields import Integer, List, Scope, String, Boolean
-
-from capa.responsetypes import registry
+from xblock.fields import Boolean, Integer, List, Scope, String
 from xmodule.mako_module import MakoTemplateBlockBase
 from xmodule.studio_editable import StudioEditableBlock
 from xmodule.util.xmodule_django import add_webpack_to_fragment
 from xmodule.validation import StudioValidation, StudioValidationMessage
-from xmodule.xml_module import XmlMixin
 from xmodule.x_module import (
+    STUDENT_VIEW,
     HTMLSnippet,
     ResourceTemplates,
-    shim_xmodule_js,
-    STUDENT_VIEW,
     XModuleMixin,
     XModuleToXBlockMixin,
+    shim_xmodule_js,
 )
-
+from xmodule.xml_module import XmlMixin
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
@@ -189,9 +188,14 @@ class LibraryContentBlock(
     @property
     def source_library_key(self):
         """
-        Convenience method to get the library ID as a LibraryLocator and not just a string
+        Convenience method to get the library ID as a LibraryLocator and not just a string.
+
+        Supports either library v1 or library v2 locators.
         """
-        return LibraryLocator.from_string(self.source_library_id)
+        try:
+            return LibraryLocator.from_string(self.source_library_id)
+        except InvalidKeyError:
+            return LibraryLocatorV2.from_string(self.source_library_id)
 
     @classmethod
     def make_selection(cls, selected, children, max_count, mode):

--- a/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -3,12 +3,12 @@
 import logging
 import sys
 
+from crum import get_current_user
 from fs.osfs import OSFS
 from lazy import lazy
 from opaque_keys.edx.locator import BlockUsageLocator, DefinitionLocator, LocalId
 from xblock.fields import ScopeIds
 from xblock.runtime import KeyValueStore, KvsFieldData
-
 from xmodule.error_module import ErrorBlock
 from xmodule.errortracker import exc_info_to_str
 from xmodule.library_tools import LibraryToolsService
@@ -74,7 +74,10 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):  # li
         self.module_data = module_data
         self.default_class = default_class
         self.local_modules = {}
-        self._services['library_tools'] = LibraryToolsService(modulestore, user_id=None)
+
+        user = get_current_user()
+        user_id = user.id if user else None
+        self._services['library_tools'] = LibraryToolsService(modulestore, user_id=user_id)
 
     @lazy
     def _parent_map(self):  # lint-amnesty, pylint: disable=missing-function-docstring

--- a/xmodule/tests/test_library_content.py
+++ b/xmodule/tests/test_library_content.py
@@ -4,16 +4,18 @@ Basic unit tests for LibraryContentBlock
 Higher-level tests are in `cms/djangoapps/contentstore/tests/test_libraries.py`.
 """
 from unittest.mock import MagicMock, Mock, patch
-import ddt
 
+import ddt
 from bson.objectid import ObjectId
 from fs.memoryfs import MemoryFS
 from lxml import etree
+from opaque_keys.edx.locator import LibraryLocator, LibraryLocatorV2
+from rest_framework import status
 from search.search_engine_base import SearchEngine
 from web_fragments.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
-from rest_framework import status
 
+from xmodule.capa_module import ProblemBlock
 from xmodule.library_content_module import ANY_CAPA_TYPE_VALUE, LibraryContentBlock
 from xmodule.library_tools import LibraryToolsService
 from xmodule.modulestore import ModuleStoreEnum
@@ -22,7 +24,6 @@ from xmodule.modulestore.tests.utils import MixedSplitTestCase
 from xmodule.tests import get_test_system
 from xmodule.validation import StudioValidationMessage
 from xmodule.x_module import AUTHOR_VIEW
-from xmodule.capa_module import ProblemBlock
 
 from .test_course_module import DummySystem as TestImportSystem
 
@@ -72,6 +73,32 @@ class LibraryContentTest(MixedSplitTestCase):
 
         module_system.get_module = get_module
         module.xmodule_runtime = module_system
+
+
+@ddt.ddt
+class LibraryContentGeneralTest(LibraryContentTest):
+    """
+    Test the base functionality of the LibraryContentBlock.
+    """
+
+    @ddt.data(
+        ('library-v1:ProblemX+PR0B', LibraryLocator),
+        ('lib:ORG:test-1', LibraryLocatorV2)
+    )
+    @ddt.unpack
+    def test_source_library_key(self, library_key, expected_locator_type):
+        """
+        Test the source_library_key property of the xblock.
+
+        The method should correctly work either with V1 or V2 libraries.
+        """
+        library = self.make_block(
+            "library_content",
+            self.vertical,
+            max_count=1,
+            source_library_id=library_key
+        )
+        assert isinstance(library.source_library_key, expected_locator_type)
 
 
 class TestLibraryContentExportImport(LibraryContentTest):

--- a/xmodule/tests/test_library_tools.py
+++ b/xmodule/tests/test_library_tools.py
@@ -1,35 +1,49 @@
 """
 Tests for library tools service.
 """
+
 from unittest.mock import patch
 
+import ddt
+from bson.objectid import ObjectId
 from opaque_keys.edx.keys import UsageKey
-from openedx.core.djangoapps.content_libraries import api as library_api
-from openedx.core.djangoapps.content_libraries.tests.base import ContentLibrariesRestApiTest
-from openedx.core.djangoapps.xblock.api import load_block
-from common.djangoapps.student.roles import CourseInstructorRole
+from opaque_keys.edx.locator import LibraryLocator, LibraryLocatorV2
 from xmodule.library_tools import LibraryToolsService
 from xmodule.modulestore.tests.factories import CourseFactory, LibraryFactory
 from xmodule.modulestore.tests.utils import MixedSplitTestCase
 
+from common.djangoapps.student.roles import CourseInstructorRole
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content_libraries import api as library_api
+from openedx.core.djangoapps.content_libraries.tests.base import ContentLibrariesRestApiTest
+from openedx.core.djangoapps.xblock.api import load_block
 
-class LibraryToolsServiceTest(MixedSplitTestCase):
-    """
-    Tests for library service.
-    """
 
+@ddt.ddt
+class ContentLibraryToolsTest(MixedSplitTestCase, ContentLibrariesRestApiTest):
+    """
+    Tests for LibraryToolsService.
+
+    Tests interaction with blockstore-based (V2) and mongo-based (V1) content libraries.
+    """
     def setUp(self):
         super().setUp()
+        UserFactory(is_staff=True, id=self.user_id)
         self.tools = LibraryToolsService(self.store, self.user_id)
 
     def test_list_available_libraries(self):
         """
         Test listing of libraries.
+
+        Should include either V1 or V2 libraries.
         """
+        # create V1 library
         _ = LibraryFactory.create(modulestore=self.store)
+        # create V2 library
+        self._create_library(slug="testlib1_preview", title="Test Library 1", description="Testing XBlocks")
         all_libraries = self.tools.list_available_libraries()
         assert all_libraries
-        assert len(all_libraries) == 1
+        assert len(all_libraries) == 2
 
     @patch('xmodule.modulestore.split_mongo.split.SplitMongoModuleStore.get_library_summaries')
     def test_list_available_libraries_fetch(self, mock_get_library_summaries):
@@ -38,15 +52,6 @@ class LibraryToolsServiceTest(MixedSplitTestCase):
         """
         _ = self.tools.list_available_libraries()
         assert mock_get_library_summaries.called
-
-
-class ContentLibraryToolsTest(MixedSplitTestCase, ContentLibrariesRestApiTest):
-    """
-    Tests for LibraryToolsService which interact with blockstore-based content libraries
-    """
-    def setUp(self):
-        super().setUp()
-        self.tools = LibraryToolsService(self.store, self.user.id)
 
     def test_import_from_blockstore(self):
         # Create a blockstore content library
@@ -94,3 +99,105 @@ class ContentLibraryToolsTest(MixedSplitTestCase, ContentLibrariesRestApiTest):
         imported_html_block = self.store.get_item(imported_unit_block.children[0])
         assert 'Hello world' not in imported_html_block.data
         assert 'Foo bar' in imported_html_block.data
+
+    def test_get_v2_library_version(self):
+        """
+        Test get_library_version for V2 libraries.
+
+        Covers getting results for either library key as a string or LibraryLocatorV2.
+
+        NOTE:
+            We don't publish library updates so the library version will always be 0.
+        """
+        lib = self._create_library(slug="testlib1-slug", title="Test Library 1", description="Testing Library 1")
+        # use library key as a string for getting the library version
+        result = self.tools.get_library_version(lib['id'])
+        assert isinstance(result, int)
+        assert result == 0
+        # now do the same but use library key as a LibraryLocatorV2
+        result2 = self.tools.get_library_version(LibraryLocatorV2.from_string(lib['id']))
+        assert isinstance(result, int)
+        assert result2 == 0
+
+    def test_get_v1_library_version(self):
+        """
+        Test get_library_version for V1 libraries.
+
+        Covers getting results for either string library key or LibraryLocator.
+        """
+        lib_key = LibraryFactory.create(modulestore=self.store).location.library_key
+        # Re-load the library from the modulestore, explicitly including version information:
+        lib = self.store.get_library(lib_key, remove_version=False, remove_branch=False)
+        # check the result using the LibraryLocator
+        assert isinstance(lib_key, LibraryLocator)
+        result = self.tools.get_library_version(lib_key)
+        assert result
+        assert isinstance(result, ObjectId)
+        assert result == lib.location.library_key.version_guid
+        # the same check for string representation of the LibraryLocator
+        str_key = str(lib_key)
+        result = self.tools.get_library_version(str_key)
+        assert result
+        assert isinstance(result, ObjectId)
+        assert result == lib.location.library_key.version_guid
+
+    @ddt.data(
+        'library-v1:Fake+Key',  # V1 library key
+        'lib:Fake:V-2',         # V2 library key
+        LibraryLocator.from_string('library-v1:Fake+Key'),
+        LibraryLocatorV2.from_string('lib:Fake:V-2'),
+    )
+    def test_get_library_version_no_library(self, lib_key):
+        """
+        Test get_library_version result when the library does not exist.
+
+        Provided lib_key's are valid V1 or V2 keys.
+        """
+        assert self.tools.get_library_version(lib_key) is None
+
+    def test_update_children_for_v2_lib(self):
+        """
+        Test update_children with V2 library as a source.
+
+        As for now, covers usage of update_children for the library content module only.
+        """
+        library = self._create_library(
+            slug="cool-v2-lib", title="The best Library", description="Spectacular description"
+        )
+        self._add_block_to_library(library["id"], "unit", "unit1_id")["id"]  # pylint: disable=expression-not-assigned
+
+        course = CourseFactory.create(modulestore=self.store, user_id=self.user.id)
+        CourseInstructorRole(course.id).add_users(self.user)
+
+        content_block = self.make_block(
+            "library_content",
+            course,
+            max_count=1,
+            source_library_id=library['id']
+        )
+
+        assert len(content_block.children) == 0
+        self.tools.update_children(content_block)
+        content_block = self.store.get_item(content_block.location)
+        assert len(content_block.children) == 1
+
+    def test_update_children_for_v1_lib(self):
+        """
+        Test update_children with V1 library as a source.
+
+        As for now, covers usage of update_children for the library content module only.
+        """
+        library = LibraryFactory.create(modulestore=self.store)
+        self.make_block("html", library, data="Hello world from the block")
+        course = CourseFactory.create(modulestore=self.store)
+        content_block = self.make_block(
+            "library_content",
+            course,
+            max_count=1,
+            source_library_id=str(library.location.library_key)
+        )
+
+        assert len(content_block.children) == 0
+        self.tools.update_children(content_block)
+        content_block = self.store.get_item(content_block.location)
+        assert len(content_block.children) == 1


### PR DESCRIPTION
**Description:** 
- V2 libraries are available for selection in the Random Block edit modal;
- selected V2 library blocks are copied to the modulestore and saved as children of the Random Block;
- V2 library version validation works the same as for the V1 libraries (with the possibility to update the block with the latest version);
- filtering by problem type can't be done for V2 the same as for V1 because the v2 library problems are not divided by types;
- problem type dropdown is hidden when V2 library selected in the block edit mode;
- unit tests added/updated.

**Youtrack:** [Link to Youtrack ticket](https://youtrack.raccoongang.com/issue/EDX_BLND_CLI-87)

