### PR TITLE
EDX_BLND_CLI-267 fix updating preview for library xblocks after uploading childrens

### DIFF
--- a/xmodule/assets/library_content/public/js/library_content_edit.js
+++ b/xmodule/assets/library_content/public/js/library_content_edit.js
@@ -37,12 +37,16 @@ window.LibraryContentAuthorView = function(runtime, element) {
     var $loader = $wrapper.find('.ui-loading');
     var $xblockHeader = $wrapper.find('.xblock-header');
     if (!$loader.hasClass('is-hidden')) {
-        var timer = setInterval(function() { 
+        var timer = setInterval(function() {
             $.get(runtime.handlerUrl(element, 'get_import_task_status'), function( data ) {
                 if (data.status == 'Succeeded') {
                     $loader.addClass('is-hidden');
                     $xblockHeader.removeClass('is-hidden');
                     clearInterval(timer);
+                    runtime.notify('save', {
+                        state: 'end',
+                        element: element
+                    });
                 }
             })
         }, 1000);

--- a/xmodule/assets/library_source_block/public/js/library_source_edit.js
+++ b/xmodule/assets/library_source_block/public/js/library_source_edit.js
@@ -43,6 +43,10 @@ window.LibrarySourceAuthorView = function(runtime, element) {
                     $loader.addClass('is-hidden');
                     $xblockHeader.removeClass('is-hidden');
                     clearInterval(timer);
+                    runtime.notify('save', {
+                        state: 'end',
+                        element: element
+                    });
                 }
             })
         }, 1000);

--- a/xmodule/library_sourced_block.py
+++ b/xmodule/library_sourced_block.py
@@ -266,6 +266,17 @@ class LibrarySourcedBlock(
             )
             return validation
 
+        if not self.children:
+            validation.set_summary(
+                StudioValidationMessage(
+                    StudioValidationMessage.NOT_CONFIGURED,
+                    _("There are no problem types in the specified libraries."),
+                    action_class='edit-button',
+                    action_label=_("Select another Library.")
+                )
+            )
+            return validation
+
         self._validate_library_version(validation, self.tools, self.source_library_version, self.source_library_key)
         return validation
 


### PR DESCRIPTION
[EDX_BLND_CLI-267](https://youtrack.raccoongang.com/issue/EDX_BLND_CLI-267) [Milestone 4.0a] Notification "There are no matching problem types in the specified libraries." for Randomized Content Block mustn't appear while course creator use 1 library in different content libraries