### PR TITLE
EDXOLDMNG-164 raise 404 for old mongo course pages

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -442,6 +442,9 @@ class StaticCourseTabView(EdxFragmentView):
         Displays a static course tab page with a given name
         """
         course_key = CourseKey.from_string(course_id)
+        if course_key.deprecated:
+            raise Http404
+
         course = get_course_with_access(request.user, 'load', course_key)
         tab = CourseTabList.get_tab_by_slug(course.tabs, tab_slug)
         if tab is None:
@@ -921,6 +924,8 @@ def dates(request, course_id):
 def progress(request, course_id, student_id=None):
     """ Display the progress page. """
     course_key = CourseKey.from_string(course_id)
+    if course_key.deprecated:
+        raise Http404
 
     if course_home_mfe_progress_tab_is_active(course_key) and not request.user.is_staff:
         end_of_redirect_url = 'progress' if not student_id else f'progress/{student_id}'

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -202,6 +202,8 @@ def use_bulk_ops(view_func):
     @wraps(view_func)
     def wrapped_view(request, course_id, *args, **kwargs):
         course_key = CourseKey.from_string(course_id)
+        if course_key.deprecated:
+            raise Http404
         with modulestore().bulk_operations(course_key):
             return view_func(request, course_key, *args, **kwargs)
     return wrapped_view

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -118,6 +118,9 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         log.error("Unable to find course with course key %s while loading the Instructor Dashboard.", course_id)
         return HttpResponseServerError()
 
+    if course_key.deprecated:
+        raise Http404
+
     course = get_course_by_id(course_key, depth=None)
 
     access = {


### PR DESCRIPTION
added raise 404 for pages:
- progress
- instructor
- discussion 

[EDXOLDMNG-164](https://youtrack.raccoongang.com/agiles/104-993/105-2666?issue=EDXOLDMNG-164) Add page with error 404 for pages