### PR TITLE
Nborovenskiy/edxoldmng 224/create a management command to transfer certificate configs to credentials

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/migrate_cert_config.py
+++ b/cms/djangoapps/contentstore/management/commands/migrate_cert_config.py
@@ -1,0 +1,242 @@
+"""
+Script to transfer course certificate configuration to Credential IDA from modulestore (old mongo (draft) and slit).
+The script is a one-time action.
+The context for this decision can be read here
+lms/djangoapps/certificates/docs/decisions/007-transfer-certificate-signatures-from-mongo.rst
+"""
+
+import attr
+from itertools import chain
+from typing import Dict, Iterator, List, Union
+
+from django.core.management.base import BaseCommand, CommandError
+
+from common.djangoapps.course_modes.models import CourseMode
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locator import CourseLocator
+from openedx.core.djangoapps.credentials.utils import send_course_certificate_configuration
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.course_module import CourseBlock
+from cms.djangoapps.contentstore.signals.handlers import (
+    create_course_certificate_config_data,
+    get_certificate_signature_assets,
+)
+from cms.djangoapps.contentstore.views.certificates import CertificateManager
+
+
+class FakedUser:
+    def __init__(self, id_: int):
+        self.id = id_
+
+
+class FakedRequest:
+    def __init__(self, user_id: int):
+        self.user = FakedUser(user_id)
+
+
+class Command(BaseCommand):
+    help = 'Allows manual transfer course certificate configuration from modulestore to Credentials IDA.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('course_ids', nargs='*', metavar='course_id')
+        parser.add_argument(
+            '--course_storage_type',
+            type=str.lower,
+            default=None,
+            choices=['all', 'draft', 'split'],
+            help='Course storage types whose certificate configurations are to be migrated.',
+        )
+        parser.add_argument(
+            '--delete-after',
+            help='Boolean value to delete course certificate configuration, signature assets from modulestore.',
+            action='store_true',
+        )
+
+    def _parse_course_key(self, raw_value: str) -> CourseKey:
+        """
+        Parses course key from string
+        """
+        try:
+            result = CourseKey.from_string(raw_value)
+        except InvalidKeyError:
+            raise CommandError(f'Invalid course_key: {raw_value}.')
+        if not isinstance(result, CourseLocator):
+            raise CommandError(f'Argument {raw_value} is not a course key')
+
+        return result
+
+    def get_mongo_courses(self):
+        """
+        Return objects for any mongo(old approach) modulestore backend course that has a certificate configuration.
+        """
+        # N.B. This code breaks many abstraction barriers. That's ok, because
+        # it's a one-time cleanup command.
+        mongo_modulestore = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
+        old_mongo_courses = mongo_modulestore.collection.find(
+            {'_id.category': 'course', 'metadata.certificates': {'$exists': 1}},
+            {
+                '_id': True,
+            },
+        )
+        for course in old_mongo_courses:
+            yield mongo_modulestore.make_course_key(
+                course['_id']['org'],
+                course['_id']['course'],
+                course['_id']['name'],
+            )
+
+    def get_split_courses(self):
+        """
+        Return objects for any split modulestore backend course that has a certificate configuration.
+        """
+        # N.B. This code breaks many abstraction barriers. That's ok, because
+        # it's a one-time cleanup command.
+        split_modulestore = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.split)
+        active_version_collection = split_modulestore.db_connection.course_index
+        structure_collection = split_modulestore.db_connection.structures
+        branches = list(
+            active_version_collection.aggregate(
+                [
+                    {
+                        '$group': {
+                            '_id': 1,
+                            'draft': {'$push': '$versions.draft-branch'},
+                            'published': {'$push': '$versions.published-branch'},
+                        }
+                    },
+                    {'$project': {'_id': 1, 'branches': {'$setUnion': ['$draft', '$published']}}},
+                ]
+            )
+        )[0]['branches']
+
+        structures = structure_collection.find(
+            {
+                '_id': {'$in': branches},
+                'blocks': {
+                    '$elemMatch': {
+                        '$and': [
+                            {'block_type': 'course'},
+                            {'fields.certificates': {'$exists': True}},
+                        ]
+                    }
+                },
+            },
+            {
+                '_id': True,
+            },
+        )
+
+        structure_ids = [struct['_id'] for struct in structures]
+        split_mongo_courses = list(
+            active_version_collection.find(
+                {
+                    '$or': [
+                        {'versions.draft-branch': {'$in': structure_ids}},
+                        {'versions.published': {'$in': structure_ids}},
+                    ]
+                },
+                {
+                    'org': True,
+                    'course': True,
+                    'run': True,
+                    'versions': True,
+                },
+            )
+        )
+        for course in split_mongo_courses:
+            yield split_modulestore.make_course_key(
+                course['org'],
+                course['course'],
+                course['run'],
+            )
+
+    def send_to_credentials(
+        self,
+        course_key: CourseKey,
+        mode: CourseMode,
+        certificate_data: Dict[str, Union[str, List[str]]]
+    ):
+        """
+        Sends certificate configuration data to Credential IDA via http request.
+        """
+        certificate_config = create_course_certificate_config_data(str(course_key), mode.slug, certificate_data)
+        files_to_upload = dict(get_certificate_signature_assets(certificate_config))
+        certificate_config_data = attr.asdict(certificate_config)
+        send_course_certificate_configuration(str(course_key), certificate_config_data, files_to_upload)
+
+    def delete_from_store(self, course: CourseBlock, certificates: List[Dict[str, str]]):
+        """
+        Deletes certificate configuration from modulestore storage.
+        """
+        store = modulestore()
+        request = FakedRequest(ModuleStoreEnum.UserID.mgmt_command)
+        for cert in certificates:
+            CertificateManager.remove_certificate(
+                request=request, store=store, course=course, certificate_id=cert['id']
+            )
+
+    def validate_input(self, options: Dict[str, str]):
+        """
+        Makes manage-command input validation. Raises CommandError if has conflicts.
+        """
+        if (not len(options['course_ids']) and not options.get('course_storage_type')) or (
+            len(options['course_ids']) and options.get('course_storage_type')
+        ):
+            raise CommandError(
+                'Certificate configurations migration requires one or more <course_id>s '
+                'OR the --course_storage_type choice.'
+            )
+
+    def get_course_keys_by_option(self, options: Dict[str, str]) -> Iterator[CourseKey]:
+        storage_type = options['course_storage_type']
+        course_ids = options['course_ids']
+        if storage_type:
+            if storage_type == 'all':
+                return chain(self.get_mongo_courses(), self.get_split_courses())
+            elif storage_type == 'draft':
+                return self.get_mongo_courses()
+            elif storage_type == 'split':
+                return self.get_split_courses()
+        if course_ids:
+            return map(self._parse_course_key, course_ids)
+
+    def migrate(self, course_keys: List[CourseKey], options: Dict[str, str]):
+        """
+        Main entry point for executiong all migration-related actions.
+
+        Sending to Credential and/or removal from storage.
+        If there are problems with some course, i.e. or it does not exist, or the course is not set to mode,
+        which allows to have a certificate, or no certificate configuration,
+        then an user of this command will be notified by a message.
+        """
+        for course_key in course_keys:
+            if course := modulestore().get_course(course_key):
+                if course_modes := CourseMode.objects.filter(
+                    course_id=course_key, mode_slug__in=CourseMode.CERTIFICATE_RELEVANT_MODES
+                ):
+                    if certificates := CertificateManager.get_certificates(course):
+                        for certificate_data in certificates:
+                            for mode in course_modes:
+                                try:
+                                    self.send_to_credentials(course_key, mode, certificate_data)
+                                except Exception as exc:
+                                    self.stderr.write(str(exc))
+                                else:
+                                    if options.get('delete_after'):
+                                        self.delete_from_store(course, certificates)
+                    else:
+                        self.stderr.write(f'The course {course_key} does not have any configured certificates.')
+                else:
+                    self.stderr.write(f'The course {course_key} does not have certificate relevant modes.')
+            else:
+                self.stderr.write(f'The course {course_key} does not exist.')
+
+    def handle(self, *args, **options):
+        """
+        Executes the command.
+        """
+        self.validate_input(options)
+        course_keys_to_migrate = self.get_course_keys_by_option(options)
+        self.migrate(course_keys_to_migrate, options)

--- a/cms/djangoapps/contentstore/management/commands/migrate_cert_config.py
+++ b/cms/djangoapps/contentstore/management/commands/migrate_cert_config.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
 
         return result
 
-    def get_mongo_courses(self):
+    def get_mongo_courses(self) -> Iterator[CourseKey]:
         """
         Return objects for any mongo(old approach) modulestore backend course that has a certificate configuration.
         """
@@ -87,7 +87,7 @@ class Command(BaseCommand):
                 course['_id']['name'],
             )
 
-    def get_split_courses(self):
+    def get_split_courses(self) -> Iterator[CourseKey]:
         """
         Return objects for any split modulestore backend course that has a certificate configuration.
         """

--- a/cms/djangoapps/contentstore/management/commands/migrate_cert_config.py
+++ b/cms/djangoapps/contentstore/management/commands/migrate_cert_config.py
@@ -37,6 +37,19 @@ class FakedRequest:
 
 
 class Command(BaseCommand):
+    """
+    Management command to transfer course certificate configuration from modulestore to Credentials IDA.
+
+    Examples:
+
+        ./manage.py migrate_cert_config <course_id_1> <course_id_2> - transfer courses with provided keys
+        ./manage.py migrate_cert_config --all - transfer all available courses
+        ./manage.py migrate_cert_config --draft - transfer all mongo(old approach) modulestore available courses
+        ./manage.py migrate_cert_config --draft - transfer all split(new approach) modulestore available courses
+        ./manage.py migrate_cert_config --all --delete-after - transfer all available courses
+        and delete course certificate configuration, signature assets from modulestore after successfull transfer.
+    """
+
     help = 'Allows manual transfer course certificate configuration from modulestore to Credentials IDA.'
 
     def add_arguments(self, parser):

--- a/cms/djangoapps/contentstore/signals/tests/test_handlers.py
+++ b/cms/djangoapps/contentstore/signals/tests/test_handlers.py
@@ -3,14 +3,10 @@ Tests for signal handlers in the contentstore.
 """
 
 import attr
-import httpretty
 from datetime import datetime
-import json
-import requests
 from unittest.mock import patch
 from django.test import TestCase
 from django.test.utils import override_settings
-from edx_rest_api_client.auth import SuppliedJwtAuth
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 from openedx_events.content_authoring.data import (
     CertificateSignatoryData,
@@ -113,7 +109,7 @@ class TestCourseCertificateConfigSignal(ModuleStoreTestCase):
         )
         self.course_key = self.course.id
         self.expected_data = CertificateConfigData(
-            course_key=self.course_key,
+            course_id=str(self.course_key),
             title=CERTIFICATE_JSON_WITH_SIGNATORIES['name'],
             is_active=CERTIFICATE_JSON_WITH_SIGNATORIES['is_active'],
             certificate_type='verified',
@@ -133,7 +129,7 @@ class TestCourseCertificateConfigSignal(ModuleStoreTestCase):
         Test that the change event is fired when course is in state where a certificate is available.
         """
         CourseModeFactory.create(mode_slug='verified', course_id=self.course.id)
-        sh.emit_course_certificate_config_changed_signal(self.course_key, CERTIFICATE_JSON_WITH_SIGNATORIES)
+        sh.emit_course_certificate_config_changed_signal(str(self.course_key), CERTIFICATE_JSON_WITH_SIGNATORIES)
         mock_signal.assert_called_once_with(certificate_config=self.expected_data)
 
     @patch('cms.djangoapps.contentstore.signals.handlers.COURSE_CERTIFICATE_CONFIG_CHANGED.send_event', autospec=True)
@@ -142,7 +138,7 @@ class TestCourseCertificateConfigSignal(ModuleStoreTestCase):
         Test that the change event is not fired when course is in state where a certificate is not available.
         """
         CourseModeFactory.create(mode_slug='audit', course_id=self.course.id)
-        sh.emit_course_certificate_config_changed_signal(self.course_key, CERTIFICATE_JSON_WITH_SIGNATORIES)
+        sh.emit_course_certificate_config_changed_signal(str(self.course_key), CERTIFICATE_JSON_WITH_SIGNATORIES)
         mock_signal.assert_not_called()
 
     @patch('cms.djangoapps.contentstore.signals.handlers.COURSE_CERTIFICATE_CONFIG_DELETED.send_event', autospec=True)
@@ -151,7 +147,7 @@ class TestCourseCertificateConfigSignal(ModuleStoreTestCase):
         Test that the delete event is fired when course is in state where a certificate is available.
         """
         CourseModeFactory.create(mode_slug='verified', course_id=self.course.id)
-        sh.emit_course_certificate_config_deleted_signal(self.course_key, CERTIFICATE_JSON_WITH_SIGNATORIES)
+        sh.emit_course_certificate_config_deleted_signal(str(self.course_key), CERTIFICATE_JSON_WITH_SIGNATORIES)
         mock_signal.assert_called_once_with(certificate_config=self.expected_data)
 
     @patch('cms.djangoapps.contentstore.signals.handlers.COURSE_CERTIFICATE_CONFIG_DELETED.send_event', autospec=True)
@@ -160,7 +156,7 @@ class TestCourseCertificateConfigSignal(ModuleStoreTestCase):
         Test that the delete event is not fired when course is in state where a certificate is not available.
         """
         CourseModeFactory.create(mode_slug='audit', course_id=self.course.id)
-        sh.emit_course_certificate_config_deleted_signal(self.course_key, CERTIFICATE_JSON_WITH_SIGNATORIES)
+        sh.emit_course_certificate_config_deleted_signal(str(self.course_key), CERTIFICATE_JSON_WITH_SIGNATORIES)
         mock_signal.assert_not_called()
 
 
@@ -176,7 +172,7 @@ class SignalCourseCertificateConfigurationListenerTestCase(TestCase):
         self.user = UserFactory(username='cred-user')
         self.course_key = CourseLocator(org='TestU', course='sig101', run='Summer2022', branch=None, version_guid=None)
         self.expected_data = CertificateConfigData(
-            course_key=str(self.course_key),
+            course_id=str(self.course_key),
             title=CERTIFICATE_JSON_WITH_SIGNATORIES['name'],
             is_active=CERTIFICATE_JSON_WITH_SIGNATORIES['is_active'],
             certificate_type='verified',
@@ -190,38 +186,28 @@ class SignalCourseCertificateConfigurationListenerTestCase(TestCase):
             ],
         )
 
-    @override_settings(CREDENTIALS_SERVICE_USERNAME='cred-user')
-    @httpretty.activate
-    @patch('cms.djangoapps.contentstore.signals.handlers.get_credentials_api_base_url')
-    def test_course_certificate_config_deleted_listener(self, mock_get_api_base_url):
+    @patch('cms.djangoapps.contentstore.signals.handlers.delete_course_certificate_configuration')
+    def test_course_certificate_config_deleted_listener(self, mock_delete_course_certificate_configuration):
         """
         Ensure the correct API call when the signal COURSE_CERTIFICATE_CONFIG_DELETED happened.
         """
-        mock_get_api_base_url.return_value = 'http://test-server/'
-        test_client = requests.Session()
-        test_client.auth = SuppliedJwtAuth('test-token')
-        httpretty.register_uri(
-            httpretty.DELETE,
-            'http://test-server/course_certificates/',
-        )
         COURSE_CERTIFICATE_CONFIG_DELETED.send_event(certificate_config=self.expected_data)
-        last_request_body = httpretty.last_request().body.decode('utf-8')
-        assert json.loads(last_request_body) == attr.asdict(self.expected_data)
 
-    @override_settings(CREDENTIALS_SERVICE_USERNAME='cred-user')
-    @httpretty.activate
-    @patch('cms.djangoapps.contentstore.signals.handlers.get_credentials_api_base_url')
-    def test_course_certificate_config_changed_listener(self, mock_get_api_base_url):
+        mock_delete_course_certificate_configuration.assert_called_once()
+        call = mock_delete_course_certificate_configuration.mock_calls[0]
+        __, (given_course_key, given_config), __ = call
+        assert given_course_key == str(self.course_key)
+        assert given_config == attr.asdict(self.expected_data)
+
+    @patch('cms.djangoapps.contentstore.signals.handlers.send_course_certificate_configuration')
+    def test_course_certificate_config_changed_listener(self, mock_send_course_certificate_configuration):
         """
         Ensure the correct API call when the signal COURSE_CERTIFICATE_CONFIG_CHANGED happened.
         """
-        mock_get_api_base_url.return_value = 'http://test-server/'
-        test_client = requests.Session()
-        test_client.auth = SuppliedJwtAuth('test-token')
-        httpretty.register_uri(
-            httpretty.POST,
-            'http://test-server/course_certificates/',
-        )
         COURSE_CERTIFICATE_CONFIG_CHANGED.send_event(certificate_config=self.expected_data)
-        last_request_body = httpretty.last_request().body.decode('utf-8')
-        assert json.loads(last_request_body) == attr.asdict(self.expected_data)
+
+        mock_send_course_certificate_configuration.assert_called_once()
+        call = mock_send_course_certificate_configuration.mock_calls[0]
+        __, (given_course_key, given_config, __), __ = call
+        assert given_course_key == str(self.course_key)
+        assert given_config == attr.asdict(self.expected_data)

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -674,7 +674,7 @@ def import_olx(self, user_id, course_key_string, archive_path, archive_name, lan
 
             if certificates := course.certificates.get('certificates'):
                 for certificate in certificates:
-                    emit_course_certificate_config_changed_signal(courselike_key, certificate)
+                    emit_course_certificate_config_changed_signal(str(courselike_key), certificate)
 
 
 @shared_task

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -455,7 +455,7 @@ def certificates_list_handler(request, course_key_string):
                     kwargs={'certificate_id': new_certificate.id}
                 )
                 store.update_item(course, request.user.id)
-                emit_course_certificate_config_changed_signal(course_key, new_certificate.certificate_data)
+                emit_course_certificate_config_changed_signal(str(course.id), new_certificate.certificate_data)
                 CertificateManager.track_event('created', {
                     'course_id': str(course.id),
                     'configuration_id': new_certificate.id
@@ -513,7 +513,7 @@ def certificates_detail_handler(request, course_key_string, certificate_id):
             certificates_list.append(serialized_certificate)
 
         store.update_item(course, request.user.id)
-        emit_course_certificate_config_changed_signal(course_key, new_certificate.certificate_data)
+        emit_course_certificate_config_changed_signal(str(course.id), new_certificate.certificate_data)
         CertificateManager.track_event(cert_event_type, {
             'course_id': str(course.id),
             'configuration_id': serialized_certificate["id"]
@@ -536,7 +536,7 @@ def certificates_detail_handler(request, course_key_string, certificate_id):
             course=course,
             certificate_id=certificate_id
         )
-        emit_course_certificate_config_deleted_signal(course_key, match_cert)
+        emit_course_certificate_config_deleted_signal(str(course.id), match_cert)
         CertificateManager.track_event('deleted', {
             'course_id': str(course.id),
             'configuration_id': certificate_id

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -1,7 +1,11 @@
 """Tests covering Credentials utilities."""
 import uuid
+import json
+import httpretty
 from unittest import mock
+from opaque_keys.edx.locator import CourseLocator
 
+from django.test import TestCase
 from django.test import override_settings
 from edx_toggles.toggles.testutils import override_waffle_switch
 
@@ -9,7 +13,12 @@ from openedx.core.djangoapps.credentials.config import USE_LEARNER_RECORD_MFE
 from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
 from openedx.core.djangoapps.credentials.tests import factories
 from openedx.core.djangoapps.credentials.tests.mixins import CredentialsApiConfigMixin
-from openedx.core.djangoapps.credentials.utils import get_credentials, get_credentials_records_url
+from openedx.core.djangoapps.credentials.utils import (
+    get_credentials,
+    get_credentials_records_url,
+    delete_course_certificate_configuration,
+    send_course_certificate_configuration,
+)
 from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from common.djangoapps.student.tests.factories import UserFactory
@@ -159,3 +168,51 @@ class TestGetCredentials(CredentialsApiConfigMixin, CacheIsolationTestCase):
 
         result = get_credentials_records_url("abcdefgh-ijkl-mnop-qrst-uvwxyz123456")
         assert result == "http://blah/abcdefghijklmnopqrstuvwxyz123456/"
+
+
+@skip_unless_lms
+class TestCourseCertificateConfiguration(TestCase):
+    """
+    Tests for course certificate configurations functions.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory(username='cred-user')
+        self.course_key = CourseLocator(org='TestU', course='sig101', run='Summer2022', branch=None, version_guid=None)
+        self.expected_body_data = {
+            'foo': 'bar',
+            'baz': 'foo'
+        }
+
+    @override_settings(CREDENTIALS_SERVICE_USERNAME='cred-user')
+    @httpretty.activate
+    @mock.patch('openedx.core.djangoapps.credentials.utils.get_credentials_api_base_url')
+    def test_course_certificate_config_deleted(self, mock_get_api_base_url):
+        """
+        Ensure the correct API call when the invoke delete_course_certificate_configuration happened.
+        """
+        mock_get_api_base_url.return_value = 'http://test-server/'
+        httpretty.register_uri(
+            httpretty.DELETE,
+            'http://test-server/course_certificates/',
+        )
+        delete_course_certificate_configuration(self.course_key, self.expected_body_data)
+        last_request_body = httpretty.last_request().body.decode('utf-8')
+        assert json.loads(last_request_body) == self.expected_body_data
+
+    @override_settings(CREDENTIALS_SERVICE_USERNAME='cred-user')
+    @httpretty.activate
+    @mock.patch('openedx.core.djangoapps.credentials.utils.get_credentials_api_base_url')
+    def test_course_certificate_config_sent(self, mock_get_api_base_url):
+        """
+        Ensure the correct API call when the invoke send_course_certificate_configuration happened.
+        """
+        mock_get_api_base_url.return_value = 'http://test-server/'
+        httpretty.register_uri(
+            httpretty.POST,
+            'http://test-server/course_certificates/',
+        )
+        send_course_certificate_configuration(self.course_key, self.expected_body_data, signature_assets={})
+        last_request_body = httpretty.last_request().body.decode('utf-8')
+        assert json.loads(last_request_body) == self.expected_body_data

--- a/openedx/core/djangoapps/credentials/utils.py
+++ b/openedx/core/djangoapps/credentials/utils.py
@@ -122,7 +122,7 @@ def get_credentials(user, program_uuid=None, credential_type=None):
     )
 
 
-def send_course_certificate_configuration(course_key: CourseKey, config_data: dict, signature_assets):
+def send_course_certificate_configuration(course_id: str, config_data: dict, signature_assets):
     try:
         credentials_client = get_credentials_api_client(
             User.objects.get(username=settings.CREDENTIALS_SERVICE_USERNAME),
@@ -135,14 +135,15 @@ def send_course_certificate_configuration(course_key: CourseKey, config_data: di
             json=config_data
         )
         response.raise_for_status()
-        log.info(f'Course certificate config sent for course {course_key} to Credentials.')
+        log.info(f'Course certificate config sent for course {course_id} to Credentials.')
     except Exception:  # lint-amnesty, pylint: disable=W0703
-        log.exception(f'Failed to send course certificate config for course {course_key} to Credentials.')
+        log.exception(f'Failed to send course certificate config for course {course_id} to Credentials.')
+        raise
     else:
         return response
 
 
-def delete_course_certificate_configuration(course_key: CourseKey, config_data: dict):
+def delete_course_certificate_configuration(course_id: str, config_data: dict):
     try:
         credentials_client = get_credentials_api_client(
             User.objects.get(username=settings.CREDENTIALS_SERVICE_USERNAME),
@@ -154,8 +155,9 @@ def delete_course_certificate_configuration(course_key: CourseKey, config_data: 
             json=config_data
         )
         response.raise_for_status()
-        log.info(f'Course certificate config is deleted for course {course_key} from Credentials.')
+        log.info(f'Course certificate config is deleted for course {course_id} from Credentials.')
     except Exception:  # lint-amnesty, pylint: disable=W0703
-        log.exception(f'Failed to delete certificate config for course {course_key} from Credentials.')
+        log.exception(f'Failed to delete certificate config for course {course_id} from Credentials.')
+        raise
     else:
         return response

--- a/openedx/core/djangoapps/credentials/utils.py
+++ b/openedx/core/djangoapps/credentials/utils.py
@@ -1,13 +1,19 @@
 """Helper functions for working with Credentials."""
+import logging
 import requests
-from edx_rest_api_client.auth import SuppliedJwtAuth
-
+from urllib.parse import urljoin  # pylint: disable=import-error
 from django.conf import settings
+from django.contrib.auth.models import User
 
+from edx_rest_api_client.auth import SuppliedJwtAuth
+from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.credentials.config import USE_LEARNER_RECORD_MFE
 from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.lib.edx_api_utils import get_api_data
+
+
+log = logging.getLogger(__name__)
 
 
 def get_credentials_records_url(program_uuid=None):
@@ -114,3 +120,42 @@ def get_credentials(user, program_uuid=None, credential_type=None):
         querystring=querystring,
         cache_key=cache_key
     )
+
+
+def send_course_certificate_configuration(course_key: CourseKey, config_data: dict, signature_assets):
+    try:
+        credentials_client = get_credentials_api_client(
+            User.objects.get(username=settings.CREDENTIALS_SERVICE_USERNAME),
+        )
+        credentials_api_base_url = get_credentials_api_base_url()
+        api_url = urljoin(f'{credentials_api_base_url}/', 'course_certificates/')
+        response = credentials_client.post(
+            api_url,
+            files=signature_assets,
+            json=config_data
+        )
+        response.raise_for_status()
+        log.info(f'Course certificate config sent for course {course_key} to Credentials.')
+    except Exception:  # lint-amnesty, pylint: disable=W0703
+        log.exception(f'Failed to send course certificate config for course {course_key} to Credentials.')
+    else:
+        return response
+
+
+def delete_course_certificate_configuration(course_key: CourseKey, config_data: dict):
+    try:
+        credentials_client = get_credentials_api_client(
+            User.objects.get(username=settings.CREDENTIALS_SERVICE_USERNAME),
+        )
+        credentials_api_base_url = get_credentials_api_base_url()
+        api_url = urljoin(f'{credentials_api_base_url}/', 'course_certificates/')
+        response = credentials_client.delete(
+            api_url,
+            json=config_data
+        )
+        response.raise_for_status()
+        log.info(f'Course certificate config is deleted for course {course_key} from Credentials.')
+    except Exception:  # lint-amnesty, pylint: disable=W0703
+        log.exception(f'Failed to delete certificate config for course {course_key} from Credentials.')
+    else:
+        return response


### PR DESCRIPTION
**Description:** This PR is going to implement a management command to transfer certificate configs to credentials.

**Youtrack:** https://youtrack.raccoongang.com/issue/EDXOLDMNG-224

**Testing instructions:**

Please call `python manage.py cms migrate_cert_config --help` to see the command capability.

**Reviewers:**
- [ ] @GlugovGrGlib 
- [x] @NiedielnitsevIvan 
- [ ] @UvgenGen 


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation in source code updated
- [ ] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
