### PR TITLE
feat: [AXIMST-387, AXIMST-381] Add waffle flag support

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -497,6 +497,66 @@ def use_new_course_team_page(course_key):
     return ENABLE_NEW_STUDIO_COURSE_TEAM_PAGE.is_enabled(course_key)
 
 
+# .. toggle_name: contentstore.new_studio_mfe.use_new_certificates_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the new studio course certificates page mfe
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-1-18
+# .. toggle_target_removal_date: 2023-4-31
+# .. toggle_tickets: ...
+# .. toggle_warning:
+ENABLE_NEW_STUDIO_CERTIFICATES_PAGE = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_new_certificates_page', __name__)
+
+
+def use_new_certificates_page(course_key):
+    """
+    Returns a boolean if new studio certificates mfe is enabled
+    """
+    return ENABLE_NEW_STUDIO_CERTIFICATES_PAGE.is_enabled(course_key)
+
+
+# .. toggle_name: contentstore.new_studio_mfe.use_new_textbooks_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the new studio course textbooks page mfe
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-1-18
+# .. toggle_target_removal_date: 2023-4-31
+# .. toggle_tickets: ...
+# .. toggle_warning:
+ENABLE_NEW_STUDIO_TEXTBOOKS_PAGE = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_new_textbooks_page', __name__)
+
+
+def use_new_textbooks_page(course_key):
+    """
+    Returns a boolean if new studio textbooks mfe is enabled
+    """
+    return ENABLE_NEW_STUDIO_TEXTBOOKS_PAGE.is_enabled(course_key)
+
+
+# .. toggle_name: contentstore.new_studio_mfe.use_new_group_configurations_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the new studio course group configurations page mfe
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-1-18
+# .. toggle_target_removal_date: 2023-4-31
+# .. toggle_tickets: ...
+# .. toggle_warning:
+ENABLE_NEW_STUDIO_GROUP_CONFIGURATIONS_PAGE = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_new_group_configurations_page', __name__)
+
+
+def use_new_group_configurations_page(course_key):
+    """
+    Returns a boolean if new studio group configurations mfe is enabled
+    """
+    return ENABLE_NEW_STUDIO_GROUP_CONFIGURATIONS_PAGE.is_enabled(course_key)
+
+
 # .. toggle_name: contentstore.mock_video_uploads
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -69,14 +69,17 @@ from cms.djangoapps.contentstore.toggles import (
     split_library_view_on_dashboard,
     use_new_advanced_settings_page,
     use_new_course_outline_page,
+    use_new_certificates_page,
     use_new_export_page,
     use_new_files_uploads_page,
     use_new_grading_page,
+    use_new_group_configurations_page,
     use_new_course_team_page,
     use_new_home_page,
     use_new_import_page,
     use_new_schedule_details_page,
     use_new_text_editor,
+    use_new_textbooks_page,
     use_new_unit_page,
     use_new_updates_page,
     use_new_video_editor,
@@ -422,6 +425,45 @@ def get_unit_url(course_locator, unit_locator) -> str:
     if use_new_unit_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
         course_mfe_url = f'{mfe_base_url}/course/{course_locator}/container/{unit_locator}'
+        if mfe_base_url:
+            unit_url = course_mfe_url
+    return unit_url
+
+
+def get_certificates_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for certificates page view.
+    """
+    unit_url = None
+    if use_new_certificates_page(course_locator):
+        mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/certificates'
+        if mfe_base_url:
+            unit_url = course_mfe_url
+    return unit_url
+
+
+def get_textbooks_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for textbooks page view.
+    """
+    unit_url = None
+    if use_new_textbooks_page(course_locator):
+        mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/textbooks'
+        if mfe_base_url:
+            unit_url = course_mfe_url
+    return unit_url
+
+
+def get_group_configurations_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for group configurations page view.
+    """
+    unit_url = None
+    if use_new_group_configurations_page(course_locator):
+        mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/group_configurations'
         if mfe_base_url:
             unit_url = course_mfe_url
     return unit_url

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -30,6 +30,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
+from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
@@ -46,8 +47,10 @@ from xmodule.modulestore import EdxJSONEncoder  # lint-amnesty, pylint: disable=
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..exceptions import AssetNotFoundException
+from ..toggles import use_new_certificates_page
 from ..utils import (
     get_certificates_context,
+    get_certificates_url,
     reverse_course_url,
 )
 from .assets import delete_asset
@@ -391,6 +394,8 @@ def certificates_list_handler(request, course_key_string):
             return JsonResponse({"error": msg}, status=403)
 
         if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
+            if use_new_certificates_page(course_key):
+                return redirect(get_certificates_url(course_key))
             certificates_context = get_certificates_context(course, request.user)
             return render_to_response('certificates.html', certificates_context)
         elif "application/json" in request.META.get('HTTP_ACCEPT'):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -86,7 +86,9 @@ from ..toggles import (
     use_new_updates_page,
     use_new_advanced_settings_page,
     use_new_grading_page,
-    use_new_schedule_details_page
+    use_new_group_configurations_page,
+    use_new_schedule_details_page,
+    use_new_textbooks_page,
 )
 from ..utils import (
     add_instructor,
@@ -98,6 +100,7 @@ from ..utils import (
     get_course_settings,
     get_grading_url,
     get_group_configurations_context,
+    get_group_configurations_url,
     get_home_context,
     get_library_context,
     get_lms_link_for_item,
@@ -105,6 +108,7 @@ from ..utils import (
     get_schedule_details_url,
     get_studio_home_url,
     get_textbooks_context,
+    get_textbooks_url,
     get_updates_url,
     initialize_permissions,
     remove_all_instructors,
@@ -1344,6 +1348,8 @@ def textbooks_list_handler(request, course_key_string):
 
         if "application/json" not in request.META.get('HTTP_ACCEPT', 'text/html'):
             # return HTML page
+            if use_new_textbooks_page(course_key):
+                return redirect(get_textbooks_url(course_key))
             textbooks_context = get_textbooks_context(course)
             return render_to_response('textbooks.html', textbooks_context)
 
@@ -1509,6 +1515,8 @@ def group_configurations_list_handler(request, course_key_string):
         course = get_course_and_check_access(course_key, request.user)
 
         if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
+            if use_new_group_configurations_page(course_key):
+                return redirect(get_group_configurations_url(course_key))
             group_configurations_context = get_group_configurations_context(course, store)
             return render_to_response('group_configurations.html', group_configurations_context)
         elif "application/json" in request.META.get('HTTP_ACCEPT'):


### PR DESCRIPTION
## Description
This PR adds WaffleFlags for the upcoming Studio MFE work. Each MFE'ed page has an associated WaffleFlags. This change impacts Developers.

WaffleFlags will be available for the following pages:
- Textbooks - `contentstore.new_studio_mfe.use_new_textbooks_page`
- Certificates - `contentstore.new_studio_mfe.use_new_certificates_page`
- Group Configurations - `contentstore.new_studio_mfe.use_new_group_configurations_page`

## Testing instructions
1. Run master devstack.
2. Start platform `make dev.up.lms+cms` and make checkout on this branch.
3. Go to `http://localhost:18010/admin/waffle/flag/`.
4. Add some of flags and change `Everyone` to `YES`
5. Open needed page in cms and make sure MFE page has opened.

## Internal tickets
[AXIMST-381](https://youtrack.raccoongang.com/issue/AXIMST-381)
[AXIMST-387](https://youtrack.raccoongang.com/issue/AXIMST-387)