### PR TITLE
fix: [AXIMST-432] 500 error appears if user adds a Content Experiment

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -14,18 +14,15 @@ from pytz import UTC
 from urllib.parse import quote
 
 import cms.djangoapps.contentstore.views.component as views
-from common.djangoapps.xblock_django.user_service import DjangoXBlockUserService
 from cms.djangoapps.contentstore.tests.test_libraries import LibraryTestCase
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID, UserPartition
-from xmodule.partitions.tests.test_partitions import PartitionTestCase
 
 from .utils import StudioPageTestCase
 
 
-class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase, PartitionTestCase):
+class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase):
     """
     Unit tests for the container page.
     """
@@ -37,24 +34,14 @@ class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase, PartitionTestCa
         super().setUp()
         self.vertical = self._create_block(self.sequential, 'vertical', 'Unit')
         self.html = self._create_block(self.vertical, "html", "HTML")
-        self.user_partition = UserPartition(
-            ENROLLMENT_TRACK_PARTITION_ID,
-            self.TEST_NAME,
-            self.TEST_DESCRIPTION,
-            self.TEST_GROUPS
-        )
         self.child_container = self._create_block(
             self.vertical,
             'split_test',
             'Split Test',
-            user_partition_id=ENROLLMENT_TRACK_PARTITION_ID,
-            user_partitions=[self.user_partition]
         )
         self.child_vertical = self._create_block(self.child_container, 'vertical', 'Child Vertical')
         self.video = self._create_block(self.child_vertical, "video", "My Video")
         self.store = modulestore()
-        user_service = DjangoXBlockUserService(self.user)
-        self.child_container.runtime._services['user'] = user_service  # pylint: disable=protected-access
 
         past = datetime.datetime(1970, 1, 1, tzinfo=UTC)
         future = datetime.datetime.now(UTC) + datetime.timedelta(days=1)

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -88,6 +88,11 @@ log = logging.getLogger(__name__)
 
 CREATE_IF_NOT_FOUND = ["course_info"]
 
+# List of categories to check for presence in the children of the XBlock.
+# This list is used to determine if all of the specified categories are absent
+# in the categories of the children XBlock instances otherwise icon class variable will be set to `None`.
+CATEGORIES_WITH_ABSENT_ICON = ["split_test"]
+
 # Useful constants for defining predicates
 NEVER = lambda x: False
 ALWAYS = lambda x: True
@@ -1064,6 +1069,10 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
         )
     else:
         user_partitions = get_user_partition_info(xblock, course=course)
+        all_excluded_categories_absent = all(
+            category not in [child.category for child in xblock.get_children()]
+            for category in CATEGORIES_WITH_ABSENT_ICON
+        )
         xblock_info.update(
             {
                 "edited_on": get_default_time_display(xblock.subtree_edited_on)
@@ -1091,7 +1100,7 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                 "group_access": xblock.group_access,
                 "user_partitions": user_partitions,
                 "show_correctness": xblock.show_correctness,
-                "xblock_type": get_icon(xblock) if is_xblock_unit else None,
+                "xblock_type": get_icon(xblock) if is_xblock_unit and all_excluded_categories_absent else None,
             }
         )
 


### PR DESCRIPTION
[AXIMST-432](https://youtrack.raccoongang.com/agiles/104-1224/105-3378?issue=AXIMST-432)

The problem arose at the stage of defining icons for children xblock's of the unit.
Just when we tried to get `get_icon_class()` for `split_test` xblock.
It was made decision to skip it.

```
File "/edx/app/edxapp/edx-platform/xmodule/vertical_block.py", line 254, in get_icon_class
    child_classes = {child.get_icon_class() for child in self.get_children()}
  File "/edx/app/edxapp/edx-platform/xmodule/vertical_block.py", line 254, in <setcomp>
    child_classes = {child.get_icon_class() for child in self.get_children()}
  File "/edx/app/edxapp/edx-platform/xmodule/split_test_block.py", line 398, in get_icon_class
    return self.child.get_icon_class() if self.child else 'other'
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/edx/app/edxapp/edx-platform/xmodule/split_test_block.py", line 176, in child
    if self.child_block is not None:
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/edx/app/edxapp/edx-platform/xmodule/split_test_block.py", line 166, in child_block
    child_blocks = self.get_child_blocks()
  File "/edx/app/edxapp/edx-platform/xmodule/split_test_block.py", line 216, in get_child_blocks
    group_id = self.get_group_id()
  File "/edx/app/edxapp/edx-platform/xmodule/split_test_block.py", line 243, in get_group_id
    user_service = self.runtime.service(self, 'user')
  File "/edx/app/edxapp/edx-platform/xmodule/modulestore/split_mongo/caching_descriptor_system.py", line 245, in service
    return super().service(block, service_name)
  File "/edx/app/edxapp/edx-platform/xmodule/x_module.py", line 1502, in service
    service = super().service(block=block, service_name=service_name)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/xblock/runtime.py", line 1125, in service
    raise NoSuchServiceError(f"Service {service_name!r} is not available.")
xblock.exceptions.NoSuchServiceError: Service 'user' is not available.
```