### PR TITLE
refactor: [ACI-502, ACI-503] redesign course grading events payload

### DIFF
--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -6,11 +6,8 @@ from logging import getLogger
 from crum import get_current_user
 from django.conf import settings
 from eventtracking import tracker
-from openedx_events.learning.data import UserCourseData, CourseData, UserData, UserPersonalData
-from openedx_events.learning.signals import (
-    COURSE_GRADE_NOW_PASSED as COURSE_GRADE_NOW_PASSED_PUBLIC,
-    COURSE_GRADE_NOW_FAILED as COURSE_GRADE_NOW_FAILED_PUBLIC,
-)
+from openedx_events.learning.data import CcxCoursePassingStatusData, CourseData, CoursePassingStatusData, UserData, UserPersonalData
+from openedx_events.learning.signals import CCX_COURSE_PASSING_STATUS_UPDATED, COURSE_PASSING_STATUS_UPDATED
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
@@ -196,8 +193,9 @@ def course_grade_now_passed(user, course_id):
         )
 
     # produce to event bus
-    COURSE_GRADE_NOW_PASSED_PUBLIC.send_event(
-        user_course_data=UserCourseData(
+    COURSE_PASSING_STATUS_UPDATED.send_event(
+        course_passing_status=CoursePassingStatusData(
+            status=CoursePassingStatusData.PASSING,
             user=UserData(
                 pii=UserPersonalData(
                     username=user.username,
@@ -210,6 +208,8 @@ def course_grade_now_passed(user, course_id):
             course=CourseData(
                 course_key=course_id,
             ),
+            update_timestamp=None,
+            grading_policy_hash=None,
         )
     )
 
@@ -233,8 +233,9 @@ def course_grade_now_failed(user, course_id):
         )
 
     # produce to event bus
-    COURSE_GRADE_NOW_FAILED_PUBLIC.send_event(
-        user_course_data=UserCourseData(
+    COURSE_PASSING_STATUS_UPDATED.send_event(
+        course_passing_status=CoursePassingStatusData(
+            status = CoursePassingStatusData.FAILING,
             user=UserData(
                 pii=UserPersonalData(
                     username=user.username,
@@ -247,6 +248,8 @@ def course_grade_now_failed(user, course_id):
             course=CourseData(
                 course_key=course_id,
             ),
+            update_timestamp=None,
+            grading_policy_hash=None,
         )
     )
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5277,15 +5277,15 @@ EVENT_BUS_TOPIC_PREFIX = "dev"
 #    Note: The topic names should not include environment prefix as it will be dynamically added based on
 #    EVENT_BUS_TOPIC_PREFIX setting.
 EVENT_BUS_PRODUCER_CONFIG = {
-    "org.openedx.learning.course.grade.now.passed.v1": {
+    "org.openedx.learning.course.passing.status.v1": {
         "learning-badges-lifecycle": {
-            "event_key_field": "user_course_data.course.course_key",
+            "event_key_field": "course_passing_status.course.course_key",
             "enabled": True,
         },
     },
-    "org.openedx.learning.course.grade.now.failed.v1": {
+    "org.openedx.learning.ccx.course.passing.status.v1": {
         "learning-badges-lifecycle": {
-            "event_key_field": "user_course_data.course.course_key",
+            "event_key_field": "course_passing_status.course.course_key",
             "enabled": True,
         },
     },


### PR DESCRIPTION
The PR switches to the updated grading public event versions defined in [related PR](https://github.com/raccoongang/openedx-events/pull/8).