### PR TITLE
refactor: [ACI-814] simplify grade status events

### DIFF
--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -208,8 +208,6 @@ def course_grade_now_passed(user, course_id):
             course=CourseData(
                 course_key=course_id,
             ),
-            update_timestamp=None,
-            grading_policy_hash=None,
         )
     )
 
@@ -248,8 +246,6 @@ def course_grade_now_failed(user, course_id):
             course=CourseData(
                 course_key=course_id,
             ),
-            update_timestamp=None,
-            grading_policy_hash=None,
         )
     )
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5277,13 +5277,13 @@ EVENT_BUS_TOPIC_PREFIX = "dev"
 #    Note: The topic names should not include environment prefix as it will be dynamically added based on
 #    EVENT_BUS_TOPIC_PREFIX setting.
 EVENT_BUS_PRODUCER_CONFIG = {
-    "org.openedx.learning.course.passing.status.v1": {
+    "org.openedx.learning.course.passing.status.updated.v1": {
         "learning-badges-lifecycle": {
             "event_key_field": "course_passing_status.course.course_key",
             "enabled": True,
         },
     },
-    "org.openedx.learning.ccx.course.passing.status.v1": {
+    "org.openedx.learning.ccx.course.passing.status.updated.v1": {
         "learning-badges-lifecycle": {
             "event_key_field": "course_passing_status.course.course_key",
             "enabled": True,


### PR DESCRIPTION
PR mirrors the openedx-events changes - uses new versions of refactored course passing status events.