### PR TITLE
fix: [AXIMST-791] Refresh cache when changing Enrollment tracks

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -21,7 +21,6 @@ from cms.djangoapps.contentstore.courseware_index import (
     CoursewareSearchIndexer,
     LibrarySearchIndexer,
 )
-from cms.djangoapps.contentstore.utils import drop_course_sidebar_blocks_cache
 from common.djangoapps.track.event_transaction_utils import get_event_transaction_id, get_event_transaction_type
 from common.djangoapps.util.block_utils import yield_dynamic_block_descendants
 from lms.djangoapps.grades.api import task_compute_all_grades_for_course
@@ -142,7 +141,6 @@ def listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=
     # register special exams asynchronously after the data is ready
     course_key_str = str(course_key)
     transaction.on_commit(lambda: update_special_exams_and_publish.delay(course_key_str))
-    drop_course_sidebar_blocks_cache(course_key_str)
 
     if key_supports_outlines(course_key):
         # Push the course outline to learning_sequences asynchronously.

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2234,3 +2234,56 @@ def send_course_update_notification(course_key, content, user):
         audience_filters={},
     )
     COURSE_NOTIFICATION_REQUESTED.send_event(course_notification_data=notification_data)
+
+
+def get_xblock_validation_messages(xblock):
+    """
+    Retrieves validation messages for a given xblock.
+    Args:
+        xblock: The xblock object to validate.
+    Returns:
+        list: A list of validation error messages.
+    """
+    validation_json = xblock.validate().to_json()
+    return validation_json['messages']
+
+
+def get_xblock_render_error(request, xblock):
+    """
+    Checks if there are any rendering errors for a given block and return these.
+    Args:
+        request: WSGI request object
+        xblock: The xblock object to rendering.
+    Returns:
+        str: Error message which happened while rendering of xblock.
+    """
+    from cms.djangoapps.contentstore.views.preview import _load_preview_block
+    from xmodule.studio_editable import has_author_view
+    from xmodule.x_module import AUTHOR_VIEW, STUDENT_VIEW
+
+    def get_xblock_render_context(request, block):
+        """
+        Return a dict of the data needs for render of each block.
+        """
+        can_edit = has_studio_write_access(request.user, block.usage_key.course_key)
+
+        return {
+            "is_unit_page": False,
+            "can_edit": can_edit,
+            "root_xblock": xblock,
+            "reorderable_items": set(),
+            "paging": None,
+            "force_render": None,
+            "item_url": "/container/{block.location}",
+            "tags_count_map": {},
+        }
+
+    try:
+        block = _load_preview_block(request, xblock)
+        preview_view = AUTHOR_VIEW if has_author_view(block) else STUDENT_VIEW
+        render_context = get_xblock_render_context(request, block)
+        block.render(preview_view, render_context)
+    except Exception as exc:  # pylint: disable=broad-except
+        return str(exc)
+
+    return ""

--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -85,6 +85,8 @@ class CourseBlockSerializer(serializers.Serializer):
         for higher_class in icon_call_priority:
             if higher_class in child_classes:
                 new_class = higher_class
+        # if 'openassessment' in child_classes:
+        #     new_class = 'fa-pencil-square-o'
         return new_class
 
 

--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -85,8 +85,7 @@ class CourseBlockSerializer(serializers.Serializer):
         for higher_class in icon_call_priority:
             if higher_class in child_classes:
                 new_class = higher_class
-        # if 'openassessment' in child_classes:
-        #     new_class = 'fa-pencil-square-o'
+
         return new_class
 
 

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -467,7 +467,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
 
     def setUp(self):
         super().setUp()
-        self.url = reverse('course-home:course-sidebar-blocks', args=[self.course.id])
+        self.url = reverse('course-home:course-navigation', args=[self.course.id])
 
     def update_course_and_overview(self):
         """
@@ -573,7 +573,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         """
         Test that the API returns a 404 when the course is not found.
         """
-        url = reverse('course-home:course-sidebar-blocks', args=['course-v1:unknown+course+2T2020'])
+        url = reverse('course-home:course-navigation', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
         assert response.status_code == 404
 
@@ -624,7 +624,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
             'suggested_icon': 'fa-foo-bar',
         }
 
-        url = reverse('course-home:course-sidebar-blocks', args=[course.id])
+        url = reverse('course-home:course-navigation', args=[course.id])
         response = self.client.get(url)
         assert response.status_code == 200
 
@@ -715,7 +715,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         """
         self.add_blocks_to_course()
         CourseEnrollment.enroll(self.user, self.course.id)
-        url = reverse('course-home:course-sidebar-blocks', args=[self.course.id])
+        url = reverse('course-home:course-navigation', args=[self.course.id])
         response = self.client.get(url)
         assert response.status_code == 200
 
@@ -731,7 +731,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         CourseEnrollment.enroll(self.user, self.course.id)
         self.create_completion(problem, int(problem_complete))
 
-        response = self.client.get(reverse('course-home:course-sidebar-blocks', args=[self.course.id]))
+        response = self.client.get(reverse('course-home:course-navigation', args=[self.course.id]))
 
         sequence_data = response.data['blocks'][str(self.sequential.location)]
         vertical_data = response.data['blocks'][str(self.vertical.location)]
@@ -750,7 +750,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         CourseEnrollment.enroll(self.user, self.course.id)
         self.create_completion(completed_problem, 1)
         self.create_completion(uncompleted_problem, 0)
-        response = self.client.get(reverse('course-home:course-sidebar-blocks', args=[self.course.id]))
+        response = self.client.get(reverse('course-home:course-navigation', args=[self.course.id]))
 
         expected_sequence_completion_stat = {
             'completion': 0,
@@ -779,7 +779,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         CourseEnrollment.enroll(self.user, self.course.id)
         self.create_completion(problem1, 1)
         self.create_completion(problem2, 1)
-        response = self.client.get(reverse('course-home:course-sidebar-blocks', args=[self.course.id]))
+        response = self.client.get(reverse('course-home:course-navigation', args=[self.course.id]))
 
         expected_sequence_completion_stat = {
             'completion': 1,

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -386,7 +386,7 @@ class CourseNavigationBlocksView(RetrieveAPIView):
     **Use Cases**
         Request details for the sidebar navigation of the course.
     **Example Requests**
-        GET api/course_home/v1/sidebar/{course_key}
+        GET api/course_home/v1/navigation/{course_key}
     **Response Values**
         For a good 200 response, the response will include:
         blocks: List of serialized Course Block objects. Each serialization has the following fields:
@@ -417,7 +417,7 @@ class CourseNavigationBlocksView(RetrieveAPIView):
     serializer_class = CourseBlockSerializer
     COURSE_BLOCKS_CACHE_KEY_TEMPLATE = (
         'course_sidebar_blocks_{course_key_string}_{course_version}_{user_id}_{user_cohort_id}'
-        '_{allow_public}_{allow_public_outline}_{is_masquerading}'
+        '_{enrollment_mode}_{allow_public}_{allow_public_outline}_{is_masquerading}'
     )
     COURSE_BLOCKS_CACHE_TIMEOUT = 60 * 60  # 1 hour
 
@@ -453,6 +453,7 @@ class CourseNavigationBlocksView(RetrieveAPIView):
             course_key_string=course_key_string,
             course_version=str(course.course_version),
             user_id=request.user.id,
+            enrollment_mode=getattr(enrollment, 'mode', ''),
             user_cohort_id=getattr(user_cohort, 'id', ''),
             allow_public=allow_public,
             allow_public_outline=allow_public_outline,

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -40,7 +40,7 @@ from lms.djangoapps.courseware.context_processor import user_timezone_locale_pre
 from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_info_section
 from lms.djangoapps.courseware.date_summary import TodaysDate
 from lms.djangoapps.courseware.masquerade import is_masquerading, setup_masquerade
-from lms.djangoapps.courseware.toggles import courseware_mfe_navigation_sidebar_blocks_caching_is_enabled
+from lms.djangoapps.courseware.toggles import courseware_disable_navigation_sidebar_blocks_caching
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.utils import OptimizelyClient
@@ -459,10 +459,11 @@ class CourseNavigationBlocksView(RetrieveAPIView):
             allow_public_outline=allow_public_outline,
             is_masquerading=user_is_masquerading,
         )
-        if courseware_mfe_navigation_sidebar_blocks_caching_is_enabled():
-            course_blocks = cache.get(cache_key)
-        else:
+
+        if navigation_sidebar_caching_is_disabled := courseware_disable_navigation_sidebar_blocks_caching():
             course_blocks = None
+        else:
+            course_blocks = cache.get(cache_key)
 
         if not course_blocks:
             if getattr(enrollment, 'is_active', False) or bool(staff_access):
@@ -470,7 +471,7 @@ class CourseNavigationBlocksView(RetrieveAPIView):
             elif allow_public_outline or allow_public or user_is_masquerading:
                 course_blocks = get_course_outline_block_tree(request, course_key_string, None)
 
-            if courseware_mfe_navigation_sidebar_blocks_caching_is_enabled():
+            if not navigation_sidebar_caching_is_disabled:
                 cache.set(cache_key, course_blocks, self.COURSE_BLOCKS_CACHE_TIMEOUT)
 
         course_blocks = self.filter_inaccessible_blocks(course_blocks, course_key)

--- a/lms/djangoapps/course_home_api/urls.py
+++ b/lms/djangoapps/course_home_api/urls.py
@@ -9,7 +9,7 @@ from django.urls import re_path
 from lms.djangoapps.course_home_api.course_metadata.views import CourseHomeMetadataView
 from lms.djangoapps.course_home_api.dates.views import DatesTabView
 from lms.djangoapps.course_home_api.outline.views import (
-    CourseSidebarBlocksView,
+    CourseNavigationBlocksView,
     OutlineTabView,
     dismiss_welcome_message,
     save_course_goal,
@@ -49,9 +49,9 @@ urlpatterns += [
         name='outline-tab'
     ),
     re_path(
-        fr'sidebar/{settings.COURSE_KEY_PATTERN}',
-        CourseSidebarBlocksView.as_view(),
-        name='course-sidebar-blocks'
+        fr'navigation/{settings.COURSE_KEY_PATTERN}',
+        CourseNavigationBlocksView.as_view(),
+        name='course-navigation'
     ),
     re_path(
         r'dismiss_welcome_message',

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -71,14 +71,16 @@ COURSEWARE_MICROFRONTEND_SEARCH_ENABLED = CourseWaffleFlag(
 # .. toggle_name: courseware.navigation_sidebar_blocks_caching
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Enable caching of navigation sidebar blocks on Learning MFE to improve performance.
+# .. toggle_description: Disable caching of navigation sidebar blocks on Learning MFE.
+# It can be used when caching the structure of large courses for a large number of users
+# at the same time can overload the cache storage (memcache or redis).
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2024-03-21
 # .. toggle_target_removal_date: None
-# .. toggle_tickets: AXIMST-682
+# .. toggle_tickets: FC-0056
 # .. toggle_warning: None.
-COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_CACHING_ENABLED = CourseWaffleFlag(
-    f'{WAFFLE_FLAG_NAMESPACE}.navigation_sidebar_blocks_caching', __name__
+COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar_blocks_caching', __name__
 )
 
 # .. toggle_name: courseware.disable_navigation_sidebar
@@ -228,8 +230,8 @@ def courseware_show_default_right_sidebar_is_enabled(course_key=None):
     return COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR.is_enabled(course_key)
 
 
-def courseware_mfe_navigation_sidebar_blocks_caching_is_enabled(course_key=None):
+def courseware_disable_navigation_sidebar_blocks_caching(course_key=None):
     """
-    Return whether the courseware.navigation_sidebar_blocks_caching flag is on.
+    Return whether the courseware.disable_navigation_sidebar_blocks_caching flag is on.
     """
-    return COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_CACHING_ENABLED.is_enabled(course_key)
+    return COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING.is_enabled(course_key)


### PR DESCRIPTION
Changes:

1.   [AXIMST-791](https://youtrack.raccoongang.com/issue/AXIMST-791) Refresh cache when changing Enrollment tracks
2.  [AXIMST-789](https://youtrack.raccoongang.com/issue/AXIMST-789) Change path to Sidebar endpoint
3.  [AXIMST-790](https://youtrack.raccoongang.com/issue/AXIMST-790) Make waffle flag to disable cache, instead of enabling
