### PR TITLE
feat: [AXM-288] Change response to represent Future assignments the s…

### DIFF
--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -267,29 +267,28 @@ class CourseEnrollmentSerializerModifiedForPrimary(CourseEnrollmentSerializer):
             self.context.get('request'),
             include_past_dates=True
         )
-        next_assignment_all = []
-        next_assignment = []
-        past_assignment = []
+        past_assignments = []
+        future_assignments = []
 
         timezone = get_user_timezone_or_last_seen_timezone_or_utc(model.user)
         for assignment in sorted(assignments, key=lambda x: x.date):
             if assignment.date < datetime.now(timezone):
-                past_assignment.append(assignment)
+                past_assignments.append(assignment)
             else:
                 if not assignment.complete:
-                    next_assignment_all.append(assignment)
+                    future_assignments.append(assignment)
 
-if future_assignments:
-        future_assignment_date = future_assignments[0].date.date()
-        next_assignments = [
-            assignment for assignment in future_assignments if assignment.date.date() == future_assignment_date
-        ]
-    else:
-        next_assignments = []
+        if future_assignments:
+            future_assignment_date = future_assignments[0].date.date()
+            next_assignments = [
+                assignment for assignment in future_assignments if assignment.date.date() == future_assignment_date
+            ]
+        else:
+            next_assignments = []
 
         return {
-            'future_assignments': DateSummarySerializer(next_assignment, many=True).data,
-            'past_assignments': DateSummarySerializer(past_assignment, many=True).data,
+            'future_assignments': DateSummarySerializer(next_assignments, many=True).data,
+            'past_assignments': DateSummarySerializer(past_assignments, many=True).data,
         }
 
     class Meta:

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -279,11 +279,13 @@ class CourseEnrollmentSerializerModifiedForPrimary(CourseEnrollmentSerializer):
                 if not assignment.complete:
                     next_assignment_all.append(assignment)
 
-        if next_assignment_all:
-            future_assignment_date = next_assignment_all[0].date.date()
-            next_assignment = [
-                assignment for assignment in next_assignment_all if assignment.date.date() == future_assignment_date
-            ]
+if future_assignments:
+        future_assignment_date = future_assignments[0].date.date()
+        next_assignments = [
+            assignment for assignment in future_assignments if assignment.date.date() == future_assignment_date
+        ]
+    else:
+        next_assignments = []
 
         return {
             'future_assignments': DateSummarySerializer(next_assignment, many=True).data,

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -903,6 +903,21 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         self.assertEqual(enrollments['results'][2]['course']['id'], str(old_course.id))
         self.assertNotIn('primary', response.data)
 
+    @patch('lms.djangoapps.mobile_api.users.serializers.cache.set', return_value=None)
+    def test_response_contains_primary_enrollment_assignments_info(self, cache_mock: MagicMock):
+        self.login()
+        course = CourseFactory.create(org='edx', mobile_available=True)
+        self.enroll(course.id)
+
+        response = self.api_response(api_version=API_V4)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('course_assignments', response.data['primary'])
+        self.assertIn('past_assignments', response.data['primary']['course_assignments'])
+        self.assertIn('future_assignments', response.data['primary']['course_assignments'])
+        self.assertListEqual(response.data['primary']['course_assignments']['past_assignments'], [])
+        self.assertListEqual(response.data['primary']['course_assignments']['future_assignments'], [])
+
 
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
 class TestUserEnrollmentCertificates(UrlResetMixin, MobileAPITestCase, MilestonesTestCaseMixin):


### PR DESCRIPTION
**Description**

Change response to represent Future assignments the same way as past assignments. Now `past_assignments` and `future_assignments` contains array with student's assignments.

**YouTrack**

https://youtrack.raccoongang.com/issue/AXM-288