### PR TITLE
feat: [AXM-373] Add push notification event about course invitations

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -141,6 +141,13 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
     """
     previous_state = EmailEnrollmentState(course_id, student_email)
     enrollment_obj = None
+    email_params.update({
+        'app_label': 'instructor',
+        'push_notification_extra_context': {
+            'notification_type': 'enroll',
+            'course_id': str(course_id),
+        },
+    })
     if previous_state.user and previous_state.user.is_active:
         # if the student is currently unenrolled, don't enroll them in their
         # previous mode
@@ -194,6 +201,13 @@ def unenroll_email(course_id, student_email, email_students=False, email_params=
         representing state before and after the action.
     """
     previous_state = EmailEnrollmentState(course_id, student_email)
+    email_params.update({
+        'app_label': 'instructor',
+        'push_notification_extra_context': {
+            'notification_type': 'unenroll',
+        },
+    })
+    import pdb;pdb.set_trace()
     if previous_state.enrollment:
         CourseEnrollment.unenroll_by_email(student_email, course_id)
         if email_students:
@@ -232,6 +246,10 @@ def send_beta_role_email(action, user, email_params):
         email_params['email_address'] = user.email
         email_params['user_id'] = user.id
         email_params['full_name'] = user.profile.name
+        email_params['app_label'] = 'instructor'
+        email_params['push_notification_extra_context'] = {
+            'notification_type': email_params['message_type'],
+        }
     else:
         raise ValueError(f"Unexpected action received '{action}' - expected 'add' or 'remove'")
     trying_to_add_inactive_user = not user.is_active and action == 'add'

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -250,6 +250,7 @@ def send_beta_role_email(action, user, email_params):
         email_params['app_label'] = 'instructor'
         email_params['push_notification_extra_context'] = {
             'notification_type': email_params['message_type'],
+            'course_id': str(getattr(email_params.get('course'), 'id', '')),
         }
     else:
         raise ValueError(f"Unexpected action received '{action}' - expected 'add' or 'remove'")

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -141,13 +141,14 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
     """
     previous_state = EmailEnrollmentState(course_id, student_email)
     enrollment_obj = None
-    email_params.update({
-        'app_label': 'instructor',
-        'push_notification_extra_context': {
-            'notification_type': 'enroll',
-            'course_id': str(course_id),
-        },
-    })
+    if email_params:
+        email_params.update({
+            'app_label': 'instructor',
+            'push_notification_extra_context': {
+                'notification_type': 'enroll',
+                'course_id': str(course_id),
+            },
+        })
     if previous_state.user and previous_state.user.is_active:
         # if the student is currently unenrolled, don't enroll them in their
         # previous mode
@@ -201,13 +202,13 @@ def unenroll_email(course_id, student_email, email_students=False, email_params=
         representing state before and after the action.
     """
     previous_state = EmailEnrollmentState(course_id, student_email)
-    email_params.update({
-        'app_label': 'instructor',
-        'push_notification_extra_context': {
-            'notification_type': 'unenroll',
-        },
-    })
-    import pdb;pdb.set_trace()
+    if email_params:
+        email_params.update({
+            'app_label': 'instructor',
+            'push_notification_extra_context': {
+                'notification_type': 'unenroll',
+            },
+        })
     if previous_state.enrollment:
         CourseEnrollment.unenroll_by_email(student_email, course_id)
         if email_students:

--- a/lms/templates/instructor/edx_ace/addbetatester/push/body.txt
+++ b/lms/templates/instructor/edx_ace/addbetatester/push/body.txt
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff. This course will remain on your dashboard, but you will no longer be part of the beta testing group.{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/addbetatester/push/body.txt
+++ b/lms/templates/instructor/edx_ace/addbetatester/push/body.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% autoescape off %}
 {% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
-{% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff. This course will remain on your dashboard, but you will no longer be part of the beta testing group.{% endblocktrans %}
+{% blocktrans %}You have been invited to be a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/addbetatester/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/addbetatester/push/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}You have been removed from a beta test for {{ course_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/addbetatester/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/addbetatester/push/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}You have been removed from a beta test for {{ course_name }}{% endblocktrans %}
+{% blocktrans %}You have been invited to a betca test for {{ course_name }}{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/allowedenroll/push/body.txt
+++ b/lms/templates/instructor/edx_ace/allowedenroll/push/body.txt
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Dear student,{% endblocktrans %}
+{% blocktrans %}You have been invited to join {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/allowedenroll/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/allowedenroll/push/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}You have been invited to register for {{ course_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/allowedunenroll/push/body.txt
+++ b/lms/templates/instructor/edx_ace/allowedunenroll/push/body.txt
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Dear Student,{% endblocktrans %}
+{% blocktrans %}You have been unenrolled from the course {{ course_name }} by a member of the course staff. Please disregard the invitation previously sent.{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/allowedunenroll/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/allowedunenroll/push/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}You have been unenrolled from {{ course_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/enrolledunenroll/push/body.txt
+++ b/lms/templates/instructor/edx_ace/enrolledunenroll/push/body.txt
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% blocktrans %}You have been unenrolled from {{ course_name }} at {{ site_name }} by a member of the course staff. This course will no longer appear on your {{ site_name }} dashboard.{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/enrolledunenroll/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/enrolledunenroll/push/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}You have been unenrolled from {{ course_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/enrollenrolled/push/body.txt
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/push/body.txt
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }} by a member of the course staff. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/enrollenrolled/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/push/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}You have been enrolled in {{ course_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/removebetatester/push/body.txt
+++ b/lms/templates/instructor/edx_ace/removebetatester/push/body.txt
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff. This course will remain on your dashboard, but you will no longer be part of the beta testing group.{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/instructor/edx_ace/removebetatester/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/removebetatester/push/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}You have been removed from a beta test for {{ course_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/openedx/core/djangoapps/notifications/policies.py
+++ b/openedx/core/djangoapps/notifications/policies.py
@@ -21,7 +21,7 @@ class CoursePushNotificationOptout(Policy):
         course_ids = message.context.get('course_ids', [])
         app_label = message.context.get('app_label')
 
-        if not (app_label or message.context.get('push_notification_extra_context', False)):
+        if not (app_label or message.context.get('push_notification_extra_context', {})):
             return PolicyResult(deny={ChannelType.PUSH})
 
         course_keys = [CourseKey.from_string(course_id) for course_id in course_ids]

--- a/openedx/core/djangoapps/notifications/policies.py
+++ b/openedx/core/djangoapps/notifications/policies.py
@@ -21,7 +21,7 @@ class CoursePushNotificationOptout(Policy):
         course_ids = message.context.get('course_ids', [])
         app_label = message.context.get('app_label')
 
-        if not (app_label or message.context.get('send_push_notification', False)):
+        if not (app_label or message.context.get('push_notification_extra_context', False)):
             return PolicyResult(deny={ChannelType.PUSH})
 
         course_keys = [CourseKey.from_string(course_id) for course_id in course_ids]


### PR DESCRIPTION
Changes:
  - add push notifications for user enroll
  - add push notifications for user unenroll
  - add push notifications for add course beta testers
  - add push notifications for remove course beta testers
  
 Youtrack:
  - [AXM-373] Add push notification event about course invitations
  - [AXM-367] Add push notification event assessment deadlines and event do not attend a course for several in a row