### PR TITLE
feat: [AXM-571] change texts in the push notifications

### DIFF
--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -116,7 +116,7 @@ def create_message_context(comment, site):
         'comment_body_text': comment.body_text,
         'comment_author_id': comment.user_id,
         'comment_created_at': comment.created_at,  # comment_client models dates are already serialized
-        'comment_parent_id': getattr(comment, 'parent_id', ''),
+        'comment_parent_id': comment.parent_id,
         'thread_id': thread.id,
         'thread_title': thread.title,
         'thread_author_id': thread.user_id,

--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -116,6 +116,7 @@ def create_message_context(comment, site):
         'comment_body_text': comment.body_text,
         'comment_author_id': comment.user_id,
         'comment_created_at': comment.created_at,  # comment_client models dates are already serialized
+        'comment_parent_id': getattr(comment, 'parent_id', ''),
         'thread_id': thread.id,
         'thread_title': thread.title,
         'thread_author_id': thread.user_id,

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -198,7 +198,7 @@ def _should_send_subcomment_message(context):
 
 
 def _comment_author_is_thread_author(context):
-    return context['comment_author_id'] == context['thread_author_id']
+    return context.get('comment_author_id', '') == context['thread_author_id']
 
 
 def _is_content_still_reported(context):
@@ -267,9 +267,9 @@ def _build_message_context(context, notification_type='forum_comment'):  # lint-
         'post_link': post_link,
         'push_notification_extra_context': {
             'course_id': str(context['course_id']),
-            'parent_id': str(context.get('comment_parent_id', '')),
+            'parent_id': str(context['comment_parent_id']),
             'notification_type': notification_type,
-            'topic_id': str(context.get('thread_commentable_id', '')),
+            'topic_id': str(context['thread_commentable_id']),
             'thread_id': context['thread_id'],
             'comment_id': context['comment_id'],
         },

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -183,18 +183,22 @@ def _should_send_message(context):
     cc_thread_author = cc.User(id=context['thread_author_id'], course_id=context['course_id'])
     return (
         _is_user_subscribed_to_thread(cc_thread_author, context['thread_id']) and
-        _is_not_subcomment(context['comment_id'])
+        _is_not_subcomment(context['comment_id']) and
+        not _comment_author_is_thread_author(context)
     )
 
 
 def _should_send_subcomment_message(context):
     cc_thread_author = cc.User(id=context['thread_author_id'], course_id=context['course_id'])
-    comment_author_is_thread_author = context['comment_author_id'] == context['thread_author_id']
     return (
         _is_user_subscribed_to_thread(cc_thread_author, context['thread_id']) and
         _is_subcomment(context['comment_id']) and
-        not comment_author_is_thread_author
+        not _comment_author_is_thread_author(context)
     )
+
+
+def _comment_author_is_thread_author(context):
+    return context['comment_author_id'] == context['thread_author_id']
 
 
 def _is_content_still_reported(context):
@@ -262,8 +266,10 @@ def _build_message_context(context, notification_type='forum_comment'):  # lint-
         'comment_username': comment_author.username,
         'post_link': post_link,
         'push_notification_extra_context': {
+            'course_id': str(context['course_id']),
+            'parent_id': str(context.get('comment_parent_id', '')),
             'notification_type': notification_type,
-            'topic_id': context.get('thread_commentable_id', ''),
+            'topic_id': str(context.get('thread_commentable_id', '')),
             'thread_id': context['thread_id'],
             'comment_id': context['comment_id'],
         },

--- a/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/push/body.txt
+++ b/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/push/body.txt
@@ -1,3 +1,2 @@
 {% load i18n %}
-{% blocktrans trimmed %}{{ comment_username }} replied to {{ thread_title }}:{% endblocktrans %}
-{{ comment_body_text }}
+{% blocktrans trimmed %}{{ comment_username }} replied to {{ thread_title }}{% endblocktrans %}

--- a/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/push/subject.txt
+++ b/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/push/subject.txt
@@ -1,3 +1,2 @@
 {% load i18n %}
-
 {% blocktrans %}Response to {{ thread_title }}{% endblocktrans %}

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -278,6 +278,7 @@ class TaskTestCase(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missin
                     'comment_body_text': comment.body_text,
                     'comment_created_at': ONE_HOUR_AGO,
                     'comment_id': comment['id'],
+                    'comment_parent_id': comment['parent_id'],
                     'comment_username': self.comment_author.username,
                     'course_id': self.course.id,
                     'thread_author_id': self.thread_author.id,
@@ -292,6 +293,8 @@ class TaskTestCase(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missin
                     'push_notification_extra_context': {
                         'notification_type': 'forum_response',
                         'topic_id': thread['commentable_id'],
+                        'course_id': comment['course_id'],
+                        'parent_id': str(comment['parent_id']),
                         'thread_id': thread['id'],
                         'comment_id': comment['id'],
                     },

--- a/lms/templates/instructor/edx_ace/addbetatester/push/body.txt
+++ b/lms/templates/instructor/edx_ace/addbetatester/push/body.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% blocktrans %}Dear {{ full_name }},{% endblocktrans %}
 {% blocktrans %}You have been invited to be a beta tester for {{ course_name }} at {{ site_name }}.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/addbetatester/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/addbetatester/push/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}You have been invited to a beta test for {{ course_name }}  at {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}You have been invited to a beta test for {{ course_name }} at {{ site_name }}.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/addbetatester/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/addbetatester/push/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}You have been invited to a beta test for {{ course_name }}{% endblocktrans %}
+{% blocktrans %}You have been invited to a beta test for {{ course_name }}  at {{ site_name }}.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/allowedenroll/push/body.txt
+++ b/lms/templates/instructor/edx_ace/allowedenroll/push/body.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% autoescape off %}
 {% blocktrans %}Dear student,{% endblocktrans %}
-{% blocktrans %}You have been invited to join {{ course_name }} at {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }}. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/allowedenroll/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/allowedenroll/push/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}You have been invited to register for {{ course_name }}{% endblocktrans %}
+{% blocktrans %}You have been invited to register for {{ course_name }}.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/enrolledunenroll/push/body.txt
+++ b/lms/templates/instructor/edx_ace/enrolledunenroll/push/body.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% blocktrans %}Dear {{ full_name }},{% endblocktrans %}
 {% blocktrans %}You have been unenrolled from {{ course_name }} at {{ site_name }}. This course will no longer appear on your {{ site_name }} dashboard.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/enrollenrolled/push/body.txt
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/push/body.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
-{% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }}. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
+{% blocktrans %}Dear {{ full_name }},{% endblocktrans %}
+{% blocktrans %}You have been invited to join {{ course_name }} at {{ site_name }}.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/removebetatester/push/body.txt
+++ b/lms/templates/instructor/edx_ace/removebetatester/push/body.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Dear {{ full_name }}{% endblocktrans %}
+{% blocktrans %}Dear {{ full_name }},{% endblocktrans %}
 {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }}. This course will remain on your dashboard, but you will no longer be part of the beta testing group.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/removebetatester/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/removebetatester/push/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}You have been removed from a beta test for {{ course_name }}{% endblocktrans %}
+{% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }}. This course will remain on your dashboard, but you will no longer be part of the beta testing group.{% endblocktrans %}
 {% endautoescape %}

--- a/lms/templates/instructor/edx_ace/removebetatester/push/subject.txt
+++ b/lms/templates/instructor/edx_ace/removebetatester/push/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }}. This course will remain on your dashboard, but you will no longer be part of the beta testing group.{% endblocktrans %}
+{% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }}.{% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
Changes: 
  - change texts in the push notifications;
  - fix notifications to thread author;
  - add topic ID to discussions push notifications context.

Youtrack:
  - [AXM-571](https://youtrack.raccoongang.com/issue/AXM-571) [notifications] Need to update notifications text
  - [AXM-572](https://youtrack.raccoongang.com/issue/AXM-572) [push_reply] The user shouldn't receive a push notification after replying to his own post