### PR TITLE
feat: [AXM-334] Allow easily adding Firebase credentials in Tutor

### DIFF
--- a/openedx/core/djangoapps/ace_common/settings/common.py
+++ b/openedx/core/djangoapps/ace_common/settings/common.py
@@ -36,7 +36,6 @@ def plugin_settings(settings):  # lint-amnesty, pylint: disable=missing-function
     settings.FIREBASE_CREDENTIALS = None
     settings.FIREBASE_APP = None
 
-    settings.FCM_APP_NAME = 'fcm-edx-platform'
     used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS_PATH', None)
     if not used_firebase_credentials:
         used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS', None)

--- a/openedx/core/djangoapps/ace_common/settings/common.py
+++ b/openedx/core/djangoapps/ace_common/settings/common.py
@@ -40,7 +40,7 @@ def plugin_settings(settings):  # lint-amnesty, pylint: disable=missing-function
     if not used_firebase_credentials:
         used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS', None)
 
-    if used_firebase_credentials:
+    settings.FIREBASE_APP = setup_firebase_app(settings.FIREBASE_CREDENTIALS_PATH or settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME)
         settings.FIREBASE_APP = setup_firebase_app(used_firebase_credentials, settings.FCM_APP_NAME)
 
     if getattr(settings, 'FIREBASE_APP', None):

--- a/openedx/core/djangoapps/ace_common/settings/common.py
+++ b/openedx/core/djangoapps/ace_common/settings/common.py
@@ -31,13 +31,18 @@ def plugin_settings(settings):  # lint-amnesty, pylint: disable=missing-function
     # Note: To local development with Firebase, you must set FIREBASE_CREDENTIALS_PATH
     # (path to json file with FIREBASE_CREDENTIALS)
     # or FIREBASE_CREDENTIALS dictionary.
+    # AND COMMENT or remove `settings.FIREBASE_APP = None` string below.
+    settings.FIREBASE_CREDENTIALS_PATH = None
+    settings.FIREBASE_CREDENTIALS = None
+    settings.FIREBASE_APP = None
+
     settings.FCM_APP_NAME = 'fcm-edx-platform'
     used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS_PATH', None)
     if not used_firebase_credentials:
         used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS', None)
 
     if used_firebase_credentials:
-        settings.FIREBASE_APP = setup_firebase_app(settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME)
+        settings.FIREBASE_APP = setup_firebase_app(used_firebase_credentials, settings.FCM_APP_NAME)
 
     if getattr(settings, 'FIREBASE_APP', None):
         settings.ACE_ENABLED_CHANNELS.append(settings.ACE_CHANNEL_DEFAULT_PUSH)

--- a/openedx/core/djangoapps/ace_common/settings/common.py
+++ b/openedx/core/djangoapps/ace_common/settings/common.py
@@ -28,11 +28,16 @@ def plugin_settings(settings):  # lint-amnesty, pylint: disable=missing-function
     settings.FCM_APP_NAME = 'fcm-edx-platform'
 
     settings.ACE_CHANNEL_DEFAULT_PUSH = 'push_notification'
-    # Note: To local development with Firebase, you must set FIREBASE_CREDENTIALS.
+    # Note: To local development with Firebase, you must set FIREBASE_CREDENTIALS_PATH
+    # (path to json file with FIREBASE_CREDENTIALS)
+    # or FIREBASE_CREDENTIALS dictionary.
     settings.FCM_APP_NAME = 'fcm-edx-platform'
-    settings.FIREBASE_CREDENTIALS = None
+    used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS_PATH', None)
+    if not used_firebase_credentials:
+        used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS', None)
 
-    settings.FIREBASE_APP = setup_firebase_app(settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME)
+    if used_firebase_credentials:
+        settings.FIREBASE_APP = setup_firebase_app(settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME)
 
     if getattr(settings, 'FIREBASE_APP', None):
         settings.ACE_ENABLED_CHANNELS.append(settings.ACE_CHANNEL_DEFAULT_PUSH)

--- a/openedx/core/djangoapps/ace_common/settings/common.py
+++ b/openedx/core/djangoapps/ace_common/settings/common.py
@@ -31,17 +31,12 @@ def plugin_settings(settings):  # lint-amnesty, pylint: disable=missing-function
     # Note: To local development with Firebase, you must set FIREBASE_CREDENTIALS_PATH
     # (path to json file with FIREBASE_CREDENTIALS)
     # or FIREBASE_CREDENTIALS dictionary.
-    # AND COMMENT or remove `settings.FIREBASE_APP = None` string below.
     settings.FIREBASE_CREDENTIALS_PATH = None
     settings.FIREBASE_CREDENTIALS = None
-    settings.FIREBASE_APP = None
 
-    used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS_PATH', None)
-    if not used_firebase_credentials:
-        used_firebase_credentials = getattr(settings, 'FIREBASE_CREDENTIALS', None)
-
-    settings.FIREBASE_APP = setup_firebase_app(settings.FIREBASE_CREDENTIALS_PATH or settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME)
-        settings.FIREBASE_APP = setup_firebase_app(used_firebase_credentials, settings.FCM_APP_NAME)
+    settings.FIREBASE_APP = setup_firebase_app(
+        settings.FIREBASE_CREDENTIALS_PATH or settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME
+    )
 
     if getattr(settings, 'FIREBASE_APP', None):
         settings.ACE_ENABLED_CHANNELS.append(settings.ACE_CHANNEL_DEFAULT_PUSH)

--- a/openedx/core/djangoapps/ace_common/settings/production.py
+++ b/openedx/core/djangoapps/ace_common/settings/production.py
@@ -28,9 +28,18 @@ def plugin_settings(settings):
         'ACE_CHANNEL_TRANSACTIONAL_EMAIL', settings.ACE_CHANNEL_TRANSACTIONAL_EMAIL
     )
     settings.FCM_APP_NAME = settings.ENV_TOKENS.get('FCM_APP_NAME', settings.FCM_APP_NAME)
+    settings.FIREBASE_CREDENTIALS_PATH = settings.ENV_TOKENS.get(
+        'FIREBASE_CREDENTIALS_PATH', settings.FIREBASE_CREDENTIALS_PATH
+    )
     settings.FIREBASE_CREDENTIALS = settings.ENV_TOKENS.get('FIREBASE_CREDENTIALS', settings.FIREBASE_CREDENTIALS)
 
-    settings.FIREBASE_APP = setup_firebase_app(settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME)
+    used_firebase_credentials = settings.FIREBASE_CREDENTIALS_PATH
+    if not used_firebase_credentials:
+        used_firebase_credentials = settings.FIREBASE_CREDENTIALS
+
+    if used_firebase_credentials:
+        settings.FIREBASE_APP = setup_firebase_app(settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME)
+
     if settings.FIREBASE_APP:
         settings.ACE_ENABLED_CHANNELS.append(settings.ACE_CHANNEL_DEFAULT_PUSH)
         settings.ACE_ENABLED_POLICIES.append('bulk_push_notification_optout')

--- a/openedx/core/djangoapps/ace_common/settings/production.py
+++ b/openedx/core/djangoapps/ace_common/settings/production.py
@@ -33,12 +33,9 @@ def plugin_settings(settings):
     )
     settings.FIREBASE_CREDENTIALS = settings.ENV_TOKENS.get('FIREBASE_CREDENTIALS', settings.FIREBASE_CREDENTIALS)
 
-    used_firebase_credentials = settings.FIREBASE_CREDENTIALS_PATH
-    if not used_firebase_credentials:
-        used_firebase_credentials = settings.FIREBASE_CREDENTIALS
-
-    if used_firebase_credentials:
-        settings.FIREBASE_APP = setup_firebase_app(used_firebase_credentials, settings.FCM_APP_NAME)
+    settings.FIREBASE_APP = setup_firebase_app(
+        settings.FIREBASE_CREDENTIALS_PATH or settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME
+    )
 
     if settings.FIREBASE_APP:
         settings.ACE_ENABLED_CHANNELS.append(settings.ACE_CHANNEL_DEFAULT_PUSH)

--- a/openedx/core/djangoapps/ace_common/settings/production.py
+++ b/openedx/core/djangoapps/ace_common/settings/production.py
@@ -38,7 +38,7 @@ def plugin_settings(settings):
         used_firebase_credentials = settings.FIREBASE_CREDENTIALS
 
     if used_firebase_credentials:
-        settings.FIREBASE_APP = setup_firebase_app(settings.FIREBASE_CREDENTIALS, settings.FCM_APP_NAME)
+        settings.FIREBASE_APP = setup_firebase_app(used_firebase_credentials, settings.FCM_APP_NAME)
 
     if settings.FIREBASE_APP:
         settings.ACE_ENABLED_CHANNELS.append(settings.ACE_CHANNEL_DEFAULT_PUSH)


### PR DESCRIPTION
## Description

Allow easily adding Firebase credentials in tutor

So, to setup `FIREBASE_CREDENTIALS` we have to do two things:

1. Mount firebase_credentials.json to `lms` and `cms` containers;
2. Setup path to `firebase_credentials.json` in Tutor Plugin.

Detail instruction, how we can setup `FIREBASE_CREDENTIALS`:

1. Create file with FIREBASE_CREDENTIALS. For example firebase_credentials.json
2. Mount created file to LMS and CMS container:
`tutor mounts add lms:<path_to_file>/firebase_credentials.json:/openedx/<path_to_file_in_lms_container>/firebase_credentials.json`
`tutor mounts add cms:<path_to_file>/firebase_credentials.json:/openedx/<path_to_file_in_lms_container>/firebase_credentials.json`
`tutor config save` - docker-compose.yml file will be regenerated. And firebase_credentials.json file will be added to lms volume.
`tutor dev restart lms cms`
3. Now firebase_credentials.json is inside lms and cms containers. We can use path to this file for setup FIREBASE_CREDENTIALS_PATH constant.
We can setup FIREBASE_CREDENTIALS_PATH in tutor plugin. There is tutor plugin example:

```
from tutor import hooks

hooks.Filters.ENV_PATCHES.add_item(
    (
        "lms-env",

"""
FCM_APP_NAME: "fcm-edx-platform"
ACE_ENABLED_CHANNELS: 
  - "django_email"
  - "push_notification"
FIREBASE_CREDENTIALS_PATH: "/openedx/<path_to_file_in_lms_container>/firebase_credentials.json"
"""
    )
)

hooks.Filters.ENV_PATCHES.add_item(
    (
        "cms-env",

"""
FCM_APP_NAME: "fcm-edx-platform"
ACE_ENABLED_CHANNELS: 
  - "django_email"
  - "push_notification"
FIREBASE_CREDENTIALS_PATH: "/openedx/edx-platform/firebase_credentials.json"
FIREBASE_CREDENTIALS: ""
"""
    )
)
```



## YouTrack

https://youtrack.raccoongang.com/issue/AXM-334
