### PR TITLE
Rework config endpoint to use for LMS frontend

### DIFF
--- a/lms/djangoapps/branding/api_urls.py
+++ b/lms/djangoapps/branding/api_urls.py
@@ -5,9 +5,9 @@ Branding API endpoint urls.
 
 from django.urls import path
 
-from lms.djangoapps.branding.views import footer, IndexPageConfigView
+from lms.djangoapps.branding.views import footer, FrontendConfigView
 
 urlpatterns = [
     path('footer', footer, name="branding_footer"),
-    path('index', IndexPageConfigView.as_view(), name="index_page_config"),
+    path('frontend-config', FrontendConfigView.as_view(), name="frontend_config"),
 ]

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -8,8 +8,9 @@ import ddt
 import six
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_switch
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.branding.models import BrandingApiConfig
@@ -18,6 +19,7 @@ from openedx.core.djangoapps.lang_pref.api import released_languages
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme_context
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
+from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
 
 
 @ddt.ddt
@@ -289,28 +291,64 @@ class TestIndex(SiteMixin, TestCase):
 
 
 @ddt.ddt
-class TestIndexPageConfig(SiteMixin, TestCase):
-    """Test the index_page_config view"""
+class TestFrontendConfig(SiteMixin, TestCase):
+    """Test the view that returns a frontend configuration for LMS pages."""
 
     def setUp(self):
         super().setUp()
-        self.url = reverse("index_page_config")
+        self.url = reverse("frontend_config")
 
-    def test_index_page_config_default_response(self):
-        """Test index_page_config returns expected default values"""
+    def test_config_includes_all_expected_keys(self):
+        """Ensure the config response includes all required keys."""
+
         response = self.client.get(self.url)
         assert response.status_code == 200
         assert response['Content-Type'] == 'application/json'
 
         config = json.loads(response.content.decode('utf-8'))
+
         assert 'enable_course_sorting_by_start_date' in config
         assert 'homepage_overlay_html' in config
         assert 'show_partners' in config
         assert 'show_homepage_promo_video' in config
         assert 'homepage_course_max' in config
         assert 'homepage_promo_video_youtube_id' in config
+        assert 'sidebar_html_enabled' in config
+        assert 'course_about_show_social_links' in config
+        assert 'course_about_twitter_account' in config
+        assert 'is_cosmetic_price_enabled' in config
 
-        # Test default values
+    @ddt.data(
+        ('ENABLE_COURSE_SORTING_BY_START_DATE', False),
+        ('homepage_overlay_html', '<p>Test overlay</p>'),
+        ('show_partners', False),
+        ('show_homepage_promo_video', True),
+        ('HOMEPAGE_COURSE_MAX', 5),
+        ('homepage_promo_video_youtube_id', 'test-youtube-id'),
+        ('course_about_show_social_links', False),
+        ('course_about_twitter_account', '@TestTwitterAccount'),
+    )
+    @ddt.unpack
+    def test_config_uses_site_configuration_values(self, key, value):
+        """Ensure config values are taken from site configuration when available."""
+
+        # Configure site with the test value
+        self.use_site(self.site)
+        self.site_configuration.site_values[key] = value
+        self.site_configuration.save()
+
+        response = self.client.get(self.url)
+        config = json.loads(response.content.decode('utf-8'))
+
+        response_key = key.lower()
+        assert config[response_key] == value
+
+    def test_config_uses_defaults_if_no_site_configuration(self):
+        """Ensure default values are returned when site configuration is missing."""
+
+        response = self.client.get(self.url)
+        config = json.loads(response.content.decode('utf-8'))
+
         assert config['show_partners'] is True
         assert config['show_homepage_promo_video'] is False
         assert config['homepage_promo_video_youtube_id'] == 'your-youtube-id'
@@ -318,75 +356,47 @@ class TestIndexPageConfig(SiteMixin, TestCase):
             'ENABLE_COURSE_SORTING_BY_START_DATE'
         )
         assert config['homepage_course_max'] == settings.HOMEPAGE_COURSE_MAX
+        assert config['course_about_show_social_links'] is True
+        assert config['course_about_twitter_account'] == settings.PLATFORM_TWITTER_ACCOUNT
 
-    @ddt.data(
-        ('ENABLE_COURSE_SORTING_BY_START_DATE', True),
-        ('ENABLE_COURSE_SORTING_BY_START_DATE', False),
-        ('homepage_overlay_html', '<p>Test overlay</p>'),
-        ('show_partners', False),
-        ('show_homepage_promo_video', True),
-        ('HOMEPAGE_COURSE_MAX', 5),
-        ('homepage_promo_video_youtube_id', 'test-youtube-id')
-    )
-    @ddt.unpack
-    def test_index_page_config_with_site_configuration(self, key, value):
-        """Test index_page_config returns values from site configuration"""
-        # Configure site with the test value
-        self.use_site(self.site)
-        site_dict = {key: value}
-        self.site_configuration.site_values.update(site_dict)
-        self.site_configuration.save()
+    def test_config_uses_settings_if_no_site_configuration(self):
+        """Ensure Django settings are used as fallback when no site configuration is provided."""
 
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-
-        config = json.loads(response.content.decode('utf-8'))
-
-        # Convert keys to the response format if needed
-        response_key = key
-        if key == 'ENABLE_COURSE_SORTING_BY_START_DATE':
-            response_key = 'enable_course_sorting_by_start_date'
-        elif key == 'HOMEPAGE_COURSE_MAX':
-            response_key = 'homepage_course_max'
-
-        assert config[response_key] == value
-
-    def test_config_falls_back_to_settings(self):
-        """Test that the configuration falls back to settings when not in site configuration"""
         self.use_site(self.site)
         self.site_configuration.site_values.clear()
         self.site_configuration.save()
 
-        with mock.patch.dict(settings.FEATURES, {'ENABLE_COURSE_SORTING_BY_START_DATE': False}):
-            with mock.patch.object(settings, 'HOMEPAGE_COURSE_MAX', 10):
-                response = self.client.get(self.url)
-                config = json.loads(response.content.decode('utf-8'))
-                assert config['enable_course_sorting_by_start_date'] is False
-                assert config['homepage_course_max'] == 10
+        expected_settings = {
+            'HOMEPAGE_COURSE_MAX': 10,
+            'PLATFORM_TWITTER_ACCOUNT': '@TestTwitterAccount',
+            'FEATURES': settings.FEATURES | {'ENABLE_COURSE_SORTING_BY_START_DATE': False},
+        }
 
-    @mock.patch('openedx.core.djangoapps.site_configuration.helpers.get_value')
-    def test_all_values_from_config_helpers(self, mock_get_value):
-        """Test that all values come from configuration helpers if available"""
-        # Setup mock to return different values for different keys
-        def side_effect(key, default=None):
-            config_values = {
-                'ENABLE_COURSE_SORTING_BY_START_DATE': True,
-                'homepage_overlay_html': '<h1>Custom Overlay</h1>',
-                'show_partners': False,
-                'show_homepage_promo_video': True,
-                'HOMEPAGE_COURSE_MAX': 7,
-                'homepage_promo_video_youtube_id': 'custom-youtube-id'
-            }
-            return config_values.get(key, default)
+        with override_settings(**expected_settings):
+            response = self.client.get(self.url)
 
-        mock_get_value.side_effect = side_effect
-
-        response = self.client.get(self.url)
         config = json.loads(response.content.decode('utf-8'))
 
-        assert config['enable_course_sorting_by_start_date'] is True
-        assert config['homepage_overlay_html'] == '<h1>Custom Overlay</h1>'
-        assert config['show_partners'] is False
-        assert config['show_homepage_promo_video'] is True
-        assert config['homepage_course_max'] == 7
-        assert config['homepage_promo_video_youtube_id'] == 'custom-youtube-id'
+        assert config['homepage_course_max'] == 10
+        assert config['course_about_twitter_account'] == '@TestTwitterAccount'
+        assert config['enable_course_sorting_by_start_date'] is False
+
+    def test_config_uses_waffle_switches(self):
+        """Ensure config reflects the current state of waffle switches."""
+
+        with override_waffle_switch(ENABLE_COURSE_ABOUT_SIDEBAR_HTML, active=True):
+            response = self.client.get(self.url)
+
+        config = json.loads(response.content.decode('utf-8'))
+
+        assert config['sidebar_html_enabled'] is True
+
+    def test_config_uses_settings_features(self):
+        """Ensure config includes feature flags defined in Django settings."""
+
+        with override_settings(FEATURES=settings.FEATURES | {'ENABLE_COSMETIC_DISPLAY_PRICE': True}):
+            response = self.client.get(self.url)
+
+        config = json.loads(response.content.decode('utf-8'))
+
+        assert config['is_cosmetic_price_enabled'] is True

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -25,6 +25,7 @@ from common.djangoapps.util.cache import cache_if_anonymous
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.lang_pref.api import released_languages
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
 
 log = logging.getLogger(__name__)
 
@@ -316,14 +317,14 @@ def footer(request):
         return HttpResponse(status=406)
 
 
-class IndexPageConfigView(APIView):
+class FrontendConfigView(APIView):
     """
-    API view to return the configuration for the index page.
+    API view to return configuration for LMS pages.
     """
 
     def get(self, request):
         """
-        Returns the configuration for the index page.
+        Returns the configuration for LMS pages.
         """
         enable_course_sorting_by_start_date = configuration_helpers.get_value(
             'ENABLE_COURSE_SORTING_BY_START_DATE',
@@ -338,6 +339,14 @@ class IndexPageConfigView(APIView):
         homepage_promo_video_youtube_id = configuration_helpers.get_value(
             'homepage_promo_video_youtube_id', 'your-youtube-id'
         )
+        sidebar_html_enabled = ENABLE_COURSE_ABOUT_SIDEBAR_HTML.is_enabled()
+        course_about_show_social_links = configuration_helpers.get_value(
+            'course_about_show_social_links', True
+        )
+        course_about_twitter_account = configuration_helpers.get_value(
+            'course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT
+        )
+        is_cosmetic_price_enabled = settings.FEATURES.get('ENABLE_COSMETIC_DISPLAY_PRICE')
 
         data = {
             "enable_course_sorting_by_start_date": enable_course_sorting_by_start_date,
@@ -346,5 +355,9 @@ class IndexPageConfigView(APIView):
             "show_homepage_promo_video": show_homepage_promo_video,
             "homepage_course_max": homepage_course_max,
             "homepage_promo_video_youtube_id": homepage_promo_video_youtube_id,
+            "sidebar_html_enabled": sidebar_html_enabled,
+            "course_about_show_social_links": course_about_show_social_links,
+            "course_about_twitter_account": course_about_twitter_account,
+            "is_cosmetic_price_enabled": is_cosmetic_price_enabled,
         }
         return Response(data)


### PR DESCRIPTION
This PR expands the frontend configuration API to make it usable for different LMS pages.
- Include additional keys/values in the response
- Rename url path & name
- Rename view
- Adjust docstrings
- Adjust tests