### PR TITLE
feat: [AXM-2707] trigger UserDate table operations in response to course events

### DIFF
--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -4,13 +4,11 @@
 from datetime import timedelta
 import logging
 
-from django.contrib.auth.models import User
 from django.db import transaction
 from django.dispatch import receiver
 from edx_when.api import FIELDS_TO_EXTRACT, set_dates_for_course
 from openedx.core.djangoapps.course_groups.signals.signals import COHORT_MEMBERSHIP_UPDATED
 
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx_events.learning.signals import (
     COURSE_ENROLLMENT_CREATED,
     COURSE_UNENROLLMENT_COMPLETED,

--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -209,8 +209,12 @@ def user_dates_on_course_enrollment(enrollment, **kwargs):
     """
     from .tasks import user_dates_on_enroll_task
 
-    course_key_str = str(enrollment.course.course_key)
-    transaction.on_commit(lambda: user_dates_on_enroll_task.delay(enrollment.user.id, course_key_str))
+    transaction.on_commit(
+        lambda: user_dates_on_enroll_task.delay(
+            enrollment.user.id,
+            str(enrollment.course.course_key)
+        )
+    )
 
 
 @receiver(COURSE_UNENROLLMENT_COMPLETED)

--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -231,8 +231,8 @@ def user_dates_on_course_unenrollment(enrollment, **kwargs):
 @receiver(COHORT_MEMBERSHIP_UPDATED)
 def user_dates_on_cohort_membership_change(sender, user, course_key, **kwargs):
     """
-   Sync UserDates for a single user when their cohort membership changes.
-   """
+    Sync UserDates for a single user when their cohort membership changes.
+    """
     from .tasks import user_dates_on_cohort_change_task
     transaction.on_commit(lambda: user_dates_on_cohort_change_task.delay(user.id, str(course_key)))
 

--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -4,9 +4,17 @@
 from datetime import timedelta
 import logging
 
+from django.contrib.auth.models import User
 from django.db import transaction
 from django.dispatch import receiver
 from edx_when.api import FIELDS_TO_EXTRACT, set_dates_for_course
+from openedx.core.djangoapps.course_groups.signals.signals import COHORT_MEMBERSHIP_UPDATED
+
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx_events.learning.signals import (
+    COURSE_ENROLLMENT_CREATED,
+    COURSE_UNENROLLMENT_COMPLETED,
+)
 from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
@@ -194,3 +202,43 @@ def update_assignment_dates(sender, course_key, **kwargs):  # pylint: disable=un
 
     course_key_str = str(course_key)
     transaction.on_commit(lambda: update_assignment_dates_for_course.delay(course_key_str))
+
+
+@receiver(COURSE_ENROLLMENT_CREATED)
+def user_dates_on_course_enrollment(enrollment, **kwargs):
+    """
+    Create UserDates for a newly enrolled user.
+    """
+    from .tasks import user_dates_on_enroll_task
+
+    course_key_str = str(enrollment.course.course_key)
+    transaction.on_commit(lambda: user_dates_on_enroll_task.delay(enrollment.user.id, course_key_str))
+
+
+@receiver(COURSE_UNENROLLMENT_COMPLETED)
+def user_dates_on_course_unenrollment(enrollment, **kwargs):
+    """
+    Delete UserDates when a user unenrolls or enrollment is deactivated.
+    """
+    from .tasks import user_dates_on_unenroll_task
+
+    course_key_str = str(enrollment.course.course_key)
+    transaction.on_commit(lambda: user_dates_on_unenroll_task.delay(enrollment.user.id, course_key_str))
+
+
+@receiver(COHORT_MEMBERSHIP_UPDATED)
+def user_dates_on_cohort_membership_change(sender, user, course_key, **kwargs):
+    """
+   Sync UserDates for a single user when their cohort membership changes.
+   """
+    from .tasks import user_dates_on_cohort_change_task
+    transaction.on_commit(lambda: user_dates_on_cohort_change_task.delay(user.id, str(course_key)))
+
+
+@receiver(SignalHandler.course_published)
+def user_dates_on_course_publish(sender, course_key, **kwargs):
+    """
+    Sync UserDates for all users in a course when it is published.
+    """
+    from .tasks import user_dates_on_course_publish_task
+    transaction.on_commit(lambda: user_dates_on_course_publish_task.delay(str(course_key)))

--- a/openedx/core/djangoapps/course_date_signals/tasks.py
+++ b/openedx/core/djangoapps/course_date_signals/tasks.py
@@ -1,6 +1,7 @@
 """
 Celery task for course date signals.
 """
+from typing import NoReturn
 
 from celery import shared_task
 from celery.utils.log import get_task_logger
@@ -45,7 +46,7 @@ def update_assignment_dates_for_course(course_key_str):
 
 @shared_task
 @set_code_owner_attribute
-def user_dates_on_enroll_task(user_id: int, course_key: str) -> None:
+def user_dates_on_enroll_task(user_id: int, course_key: str) -> None | NoReturn:
     """
     Generate UserDate records when a user enrolls in a course.
 
@@ -76,7 +77,7 @@ def user_dates_on_enroll_task(user_id: int, course_key: str) -> None:
 
 @shared_task
 @set_code_owner_attribute
-def user_dates_on_unenroll_task(user_id, course_key):
+def user_dates_on_unenroll_task(user_id, course_key) -> None | NoReturn:
     """
     Remove UserDate records when a user unenrolls from a course.
 
@@ -97,7 +98,7 @@ def user_dates_on_unenroll_task(user_id, course_key):
 
 @shared_task
 @set_code_owner_attribute
-def user_dates_on_cohort_change_task(user_id: int, course_key: str) -> None:
+def user_dates_on_cohort_change_task(user_id: int, course_key: str) -> None | NoReturn:
     """
     Synchronize UserDate records when a user's cohort membership changes (added to, or removed from, a cohort).
 
@@ -125,7 +126,7 @@ def user_dates_on_cohort_change_task(user_id: int, course_key: str) -> None:
 
 @shared_task
 @set_code_owner_attribute
-def user_dates_on_course_publish_task(course_key: str):
+def user_dates_on_course_publish_task(course_key: str) -> None | NoReturn:
     """
     Trigger batch synchronization of UserDate records for all users in the course when any course content is published.
 
@@ -155,7 +156,7 @@ def user_dates_on_course_publish_task(course_key: str):
 
 @shared_task
 @set_code_owner_attribute
-def sync_user_dates_batch_task(user_ids: list, course_key: str, course_data: dict) -> None:
+def sync_user_dates_batch_task(user_ids: list, course_key: str, course_data: dict) -> None | NoReturn:
     """
     Synchronize UserDate records for a batch of users.
     """

--- a/openedx/core/djangoapps/course_date_signals/tasks.py
+++ b/openedx/core/djangoapps/course_date_signals/tasks.py
@@ -6,9 +6,12 @@ from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.contrib.auth import get_user_model
 from edx_django_utils.monitoring import set_code_owner_attribute
-from edx_when.api import update_or_create_assignments_due_dates
-from opaque_keys.edx.keys import CourseKey
+from edx_when.api import update_or_create_assignments_due_dates, UserDateHandler
 
+from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.courseware.courses import get_course_assignments
 
 
@@ -36,4 +39,135 @@ def update_assignment_dates_for_course(course_key_str):
         LOGGER.info("Successfully updated assignment dates for course %s", course_key_str)
     except Exception:  # pylint: disable=broad-except
         LOGGER.exception("Could not update assignment dates for course %s", course_key_str)
+        raise
+
+
+@shared_task
+@set_code_owner_attribute
+def user_dates_on_enroll_task(user_id: int, course_key: str) -> None:
+    """
+    Generate UserDate records when a user enrolls in a course.
+
+    Args:
+        user_id (int): ID of the enrolled user
+        course_key (str): key identifying the course
+    """
+    LOGGER.info(f"Starting to create user dates on enrollment for user_id={user_id} in {course_key}")
+    try:
+        course_key_obj = CourseKey.from_string(course_key)
+        assignments = get_course_assignments(
+            course_key_obj,
+            User.objects.get(pk=user_id),
+            include_access=True
+        )
+        course_overview = CourseOverview.get_from_id(course_key_obj)
+        course_data = {
+            "start": course_overview.start,
+            "end": course_overview.end,
+            "location": str(course_overview.location),
+        }
+        UserDateHandler(course_key).create_for_user(user_id, assignments, course_data)
+        LOGGER.info(f"Successfully created user dates on enrollment for user_id={user_id} in {course_key}")
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception(f"Could not create user dates on enrollment for user_id={user_id} in {course_key}")
+        raise
+
+
+@shared_task
+@set_code_owner_attribute
+def user_dates_on_unenroll_task(user_id, course_key):
+    """
+    Remove UserDate records when a user unenrolls from a course.
+
+    Args:
+        user_id (int): ID of the unenrolled user
+        course_key (str): key identifying the course
+    """
+    LOGGER.info(f"Starting to delete user dates on unenrollment for user_id={user_id} in {course_key}")
+    try:
+        deleted = UserDateHandler(course_key).delete_for_user(user_id)
+        LOGGER.info(
+            f"Successfully deleted user dates on unenrollment for user_id={user_id} in {course_key}: {deleted}"
+        )
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception(f"Could not delete user dates on unenrollment for user_id={user_id} in {course_key}")
+        raise
+
+
+@shared_task
+@set_code_owner_attribute
+def user_dates_on_cohort_change_task(user_id: int, course_key: str) -> None:
+    """
+    Synchronize UserDate records when a user's cohort membership changes (added to, or removed from, a cohort).
+
+    Args:
+        user_id (int): ID of the user whose cohort membership changed
+        course_key (str): key identifying the course
+    """
+    LOGGER.info(f"Starting to sync user dates on cohort membership change for user_id={user_id} in {course_key}")
+    try:
+        assignments = get_course_assignments(
+            CourseKey.from_string(course_key),
+            User.objects.get(pk=user_id),
+            include_access=True
+        )
+        UserDateHandler(course_key).sync_for_user(user_id, assignments)
+        LOGGER.info(
+            f"Successfully synced user dates on cohort membership change for user_id={user_id} in {course_key}"
+        )
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception(
+            f"Could not update user dates on cohort membership change for user_id={user_id} in {course_key}"
+        )
+        raise
+
+
+@shared_task
+@set_code_owner_attribute
+def user_dates_on_course_publish_task(course_key: str):
+    """
+    Trigger batch synchronization of UserDate records for all users in the course when any course content is published.
+
+    Args:
+        course_key (str): key identifying the course
+    """
+    LOGGER.info(f"Starting to sync user dates on publishing {course_key}")
+    try:
+        course_key_obj = CourseKey.from_string(course_key)
+        course_overview = CourseOverview.get_from_id(course_key_obj)
+        course_data = {
+            "start": course_overview.start,
+            "end": course_overview.end,
+            "location": str(course_overview.location),
+        }
+        user_ids = list(
+            CourseEnrollment.objects.filter(course_id=course_key, is_active=True).values_list("user_id", flat=True)
+        )
+        batch_size = 500
+        for i in range(0, len(user_ids), batch_size):
+            batch = user_ids[i:i + batch_size]
+            sync_user_dates_batch_task.delay(batch, course_key, course_data)
+        LOGGER.info(f"Successfully completed syncing user dates on publishing {course_key}")
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception(f"Could not sync user dates on publishing {course_key}")
+        raise
+
+
+@shared_task
+@set_code_owner_attribute
+def sync_user_dates_batch_task(user_ids: list, course_key: str, course_data: dict) -> None:
+    """
+    Synchronize UserDate records for a batch of users.
+    """
+    LOGGER.info(f"Starting to sync user dates for a batch of {len(user_ids)} users in {course_key}")
+    try:
+        course_key_obj = CourseKey.from_string(course_key)
+        user_date_handler = UserDateHandler(course_key)
+
+        for user_id in user_ids:
+            assignments = get_course_assignments(course_key_obj, User.objects.get(id=user_id), include_access=True)
+            user_date_handler.sync_for_user(user_id, assignments, course_data)
+        LOGGER.info(f"Successfully completed syncing user dates for a batch of {len(user_ids)} users in {course_key}")
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception(f"Could not batch sync user dates for {course_key}")
         raise

--- a/openedx/core/djangoapps/course_date_signals/tasks.py
+++ b/openedx/core/djangoapps/course_date_signals/tasks.py
@@ -19,6 +19,7 @@ User = get_user_model()
 
 
 LOGGER = get_task_logger(__name__)
+USER_BATCH_SIZE = 500
 
 
 @shared_task
@@ -143,9 +144,8 @@ def user_dates_on_course_publish_task(course_key: str):
         user_ids = list(
             CourseEnrollment.objects.filter(course_id=course_key, is_active=True).values_list("user_id", flat=True)
         )
-        batch_size = 500
-        for i in range(0, len(user_ids), batch_size):
-            batch = user_ids[i:i + batch_size]
+        for i in range(0, len(user_ids), USER_BATCH_SIZE):
+            batch = user_ids[i:i + USER_BATCH_SIZE]
             sync_user_dates_batch_task.delay(batch, course_key, course_data)
         LOGGER.info(f"Successfully completed syncing user dates on publishing {course_key}")
     except Exception:  # pylint: disable=broad-except

--- a/openedx/core/djangoapps/course_date_signals/tasks.py
+++ b/openedx/core/djangoapps/course_date_signals/tasks.py
@@ -53,7 +53,7 @@ def user_dates_on_enroll_task(user_id: int, course_key: str) -> None:
         user_id (int): ID of the enrolled user
         course_key (str): key identifying the course
     """
-    LOGGER.info(f"Starting to create user dates on enrollment for user_id={user_id} in {course_key}")
+    LOGGER.debug(f"Starting to create user dates on enrollment for user_id={user_id} in {course_key}")
     try:
         course_key_obj = CourseKey.from_string(course_key)
         assignments = get_course_assignments(
@@ -68,7 +68,7 @@ def user_dates_on_enroll_task(user_id: int, course_key: str) -> None:
             "location": str(course_overview.location),
         }
         UserDateHandler(course_key).create_for_user(user_id, assignments, course_data)
-        LOGGER.info(f"Successfully created user dates on enrollment for user_id={user_id} in {course_key}")
+        LOGGER.debug(f"Successfully created user dates on enrollment for user_id={user_id} in {course_key}")
     except Exception:  # pylint: disable=broad-except
         LOGGER.exception(f"Could not create user dates on enrollment for user_id={user_id} in {course_key}")
         raise
@@ -84,10 +84,10 @@ def user_dates_on_unenroll_task(user_id, course_key):
         user_id (int): ID of the unenrolled user
         course_key (str): key identifying the course
     """
-    LOGGER.info(f"Starting to delete user dates on unenrollment for user_id={user_id} in {course_key}")
+    LOGGER.debug(f"Starting to delete user dates on unenrollment for user_id={user_id} in {course_key}")
     try:
         deleted = UserDateHandler(course_key).delete_for_user(user_id)
-        LOGGER.info(
+        LOGGER.debug(
             f"Successfully deleted user dates on unenrollment for user_id={user_id} in {course_key}: {deleted}"
         )
     except Exception:  # pylint: disable=broad-except
@@ -105,7 +105,7 @@ def user_dates_on_cohort_change_task(user_id: int, course_key: str) -> None:
         user_id (int): ID of the user whose cohort membership changed
         course_key (str): key identifying the course
     """
-    LOGGER.info(f"Starting to sync user dates on cohort membership change for user_id={user_id} in {course_key}")
+    LOGGER.debug(f"Starting to sync user dates on cohort membership change for user_id={user_id} in {course_key}")
     try:
         assignments = get_course_assignments(
             CourseKey.from_string(course_key),
@@ -113,7 +113,7 @@ def user_dates_on_cohort_change_task(user_id: int, course_key: str) -> None:
             include_access=True
         )
         UserDateHandler(course_key).sync_for_user(user_id, assignments)
-        LOGGER.info(
+        LOGGER.debug(
             f"Successfully synced user dates on cohort membership change for user_id={user_id} in {course_key}"
         )
     except Exception:  # pylint: disable=broad-except
@@ -132,7 +132,7 @@ def user_dates_on_course_publish_task(course_key: str):
     Args:
         course_key (str): key identifying the course
     """
-    LOGGER.info(f"Starting to sync user dates on publishing {course_key}")
+    LOGGER.debug(f"Starting to sync user dates on publishing {course_key}")
     try:
         course_key_obj = CourseKey.from_string(course_key)
         course_overview = CourseOverview.get_from_id(course_key_obj)
@@ -147,7 +147,7 @@ def user_dates_on_course_publish_task(course_key: str):
         for i in range(0, len(user_ids), USER_BATCH_SIZE):
             batch = user_ids[i:i + USER_BATCH_SIZE]
             sync_user_dates_batch_task.delay(batch, course_key, course_data)
-        LOGGER.info(f"Successfully completed syncing user dates on publishing {course_key}")
+        LOGGER.debug(f"Successfully completed syncing user dates on publishing {course_key}")
     except Exception:  # pylint: disable=broad-except
         LOGGER.exception(f"Could not sync user dates on publishing {course_key}")
         raise
@@ -159,7 +159,7 @@ def sync_user_dates_batch_task(user_ids: list, course_key: str, course_data: dic
     """
     Synchronize UserDate records for a batch of users.
     """
-    LOGGER.info(f"Starting to sync user dates for a batch of {len(user_ids)} users in {course_key}")
+    LOGGER.debug(f"Starting to sync user dates for a batch of {len(user_ids)} users in {course_key}")
     try:
         course_key_obj = CourseKey.from_string(course_key)
         user_date_handler = UserDateHandler(course_key)
@@ -167,7 +167,7 @@ def sync_user_dates_batch_task(user_ids: list, course_key: str, course_data: dic
         for user_id in user_ids:
             assignments = get_course_assignments(course_key_obj, User.objects.get(id=user_id), include_access=True)
             user_date_handler.sync_for_user(user_id, assignments, course_data)
-        LOGGER.info(f"Successfully completed syncing user dates for a batch of {len(user_ids)} users in {course_key}")
+        LOGGER.debug(f"Successfully completed syncing user dates for a batch of {len(user_ids)} users in {course_key}")
     except Exception:  # pylint: disable=broad-except
         LOGGER.exception(f"Could not batch sync user dates for {course_key}")
         raise

--- a/openedx/core/djangoapps/course_date_signals/tests.py
+++ b/openedx/core/djangoapps/course_date_signals/tests.py
@@ -511,7 +511,7 @@ class TestUserDateTasks(ModuleStoreTestCase):
         handler_instance.create_for_user.assert_called_once_with(
             self.user.id,
             ["assignment_1"],
-            {"start": course_overview.start, "end": course_overview.end, "location": str(course_overview._location)},
+            {"start": course_overview.start, "end": course_overview.end, "location": str(course_overview.location)},
         )
 
     @patch("openedx.core.djangoapps.course_date_signals.tasks.UserDateHandler")
@@ -554,7 +554,7 @@ class TestUserDateTasks(ModuleStoreTestCase):
         self.assertDictEqual(course_data, {
             "start": course_overview.start,
             "end": course_overview.end,
-            "location": str(course_overview._location)
+            "location": str(course_overview.location)
         })
 
     @patch("openedx.core.djangoapps.course_date_signals.tasks.UserDateHandler")
@@ -570,7 +570,7 @@ class TestUserDateTasks(ModuleStoreTestCase):
         course_data = {
             "start": course_overview.start,
             "end": course_overview.end,
-            "location": str(course_overview._location)
+            "location": str(course_overview.location)
         }
         tasks.sync_user_dates_batch_task([self.user.id], str(self.course.id), course_data)
 


### PR DESCRIPTION
> **Depends on:** https://github.com/raccoongang/edx-when/pull/7

### Summary
This PR adds functionality that triggers operations on the `UserDate` table ( from `edx-when`) in response to specific course event.

### Core Logic
The core logic is based on the following chain of actions:

1. A signal is emitted.
2. The listening receiver function triggers an appropriate Celery task.
3. The Celery task delegates the actual business logic to the `edx_when.api.UserDateHandler` class

### Cases Covered
The PR adds four receiver functions that listen to four signals:
1. `COURSE_ENROLLMENT_CREATED`
2. `COURSE_UNENROLLMENT_COMPLETED`
3. `COHORT_MEMBERSHIP_UPDATED`
4. `course_published`

This set of signals should cover all busines cases in which the `UserDate` table requires updating:
- User is enrolled in a course
- User is unenrolled from a course
- User is added to a cohort
- User is removed from a cohort
- Date is added/changed for the course
- Date is added/changed for an assignment
- An assignment becomes hidden
- An assignment becomes visible
- An assignment becomes gated behind a prerequisite