### PR TITLE
feat: [AXM-2760] add "completion" field to course progress API

### DIFF
--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -282,6 +282,9 @@ class ProgressTabView(RetrieveAPIView):
 
     @staticmethod
     def _add_completion(course_blocks, ctx, serialized_data) -> None:
+        """
+        Sets 'completion' field for each element under 'section_scores' -> 'subsections'
+        """
         completion_context = {
             "block_structure": ctx["course_blocks"],
             "requested_fields": ["children", "completion"]

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -294,5 +294,5 @@ class ProgressTabView(RetrieveAPIView):
 
         for section in serialized_data["section_scores"]:
             for subsection in section["subsections"]:
-                subsection_key= subsection["block_key"]
+                subsection_key = subsection["block_key"]
                 subsection["completion"] = blocks.get(subsection_key).get("completion")

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -119,6 +119,8 @@ class ProgressTabView(RetrieveAPIView):
                 show_grades: (bool) a bool for whether to show grades based on the access the user has
                 url: (str or None) the absolute path url to the Subsection or None if the Subsection is no longer
                      accessible to the learner due to a hide_after_due course team setting
+                completion (int or None): a boolean-like value to mark an assignment either as completed (1)
+                                                                                        or not completed (0)
         studio_url: (str) a str of the link to the grading in studio for the course
         user_has_passing_grade: (bool) boolean on if the user has a passing grade in the course
         username: (str) username of the student whose progress information is being displayed.


### PR DESCRIPTION
### Summary
This PR adds a `completion` field to each subsection returned by the Course Progress API (`ProgressTabView`).
The new field is added under `section_scores` -> `subsections` -> `completion`.

### Example of a `GET` request:
`local.openedx.io:8000/api/course_home/progress/course-v1:OpenedX+DemoX+DemoCourse`

### Example of a `GET` response (abbreviated):
```
"section_scores": [
        {
            "display_name": "Module 1: Dive into the Open edX® platform!",
            "subsections": [
                {
                    "assignment_type": null,
                    "block_key": "block-v1:OpenedX+DemoX+DemoCourse+type@sequential+block@4e1de5e13fc3422997fe246b40a43aa1",
                    "display_name": "Introduction to the Open edX® platform",
                    "has_graded_assignment": false,
                    ...
                    "show_correctness": "always",
                    "show_grades": true,
                    "completion": 0  # new field
                },
```