### PR TITLE
feat: [AXM-2286] add relative user dates logic

### DIFF
--- a/lms/djangoapps/mobile_api/course_dates/views.py
+++ b/lms/djangoapps/mobile_api/course_dates/views.py
@@ -5,10 +5,12 @@ API views for course dates.
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from edx_when.api import _are_relative_dates_enabled
 from edx_when.models import UserDate
 from rest_framework import views
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
+from xmodule.modulestore.django import modulestore
 
 from ..decorators import mobile_view
 from .serializers import AllCourseDatesSerializer
@@ -63,13 +65,25 @@ class AllCourseDatesAPIView(views.APIView):
 
     def get(self, request, *args, **kwargs) -> Response:
         user = get_object_or_404(User, username=kwargs.get("username"))
-
         user_dates = UserDate.objects.filter(user=user).select_related("content_date", "content_date__policy")
         now = timezone.now()
-        user_dates_sorted = sorted(
-            [user_date for user_date in user_dates if user_date.actual_date > now],
-            key=lambda user_date: user_date.actual_date
-        )
+
+        user_dates_filtered = []
+        for user_date in user_dates:
+            is_date_in_future = user_date.actual_date > now
+
+            is_date_relative = user_date.rel_date is not None or user_date.content_date.policy.rel_date is not None
+            course_id = user_date.content_date.course_id
+            course = modulestore().get_course(course_id)
+            is_course_relative = all(
+                [course.self_paced, _are_relative_dates_enabled(course_id), bool(course.relative_weeks_due)]
+            )
+
+            if is_date_in_future or (is_date_relative and is_course_relative):
+                user_dates_filtered.append(user_date)
+
+        user_dates_sorted = sorted(user_dates_filtered, key=lambda ud: ud.actual_date)
+
         paginator = self.pagination_class()
         paginated_data = paginator.paginate_queryset(user_dates_sorted, request)
         serializer = AllCourseDatesSerializer(paginated_data, many=True)

--- a/lms/djangoapps/mobile_api/tests/test_course_dates_views.py
+++ b/lms/djangoapps/mobile_api/tests/test_course_dates_views.py
@@ -48,9 +48,9 @@ class TestAllCourseDatesAPIView(
         UserDate.objects.all().delete()
         super().tearDown()
 
-    def test_only_future_dates_are_returned(self):
+    def test_future_dates_are_included(self):
         """
-        Ensure GET only returns user dates strictly after now().
+        Ensure GET returns user dates strictly after now().
         We create 3 UserDates: 1 in the past, 1 in the present, 1 in the future.
         We expect to get back 1 UserDate - the one from the future.
         """
@@ -101,4 +101,57 @@ class TestAllCourseDatesAPIView(
         self.login_and_enroll(self.course_1.id)
         response = self.api_response(username=self.user.username)
 
+        self.assertListEqual(response.data["results"], [])
+
+    def test_relative_dates_are_included_even_if_past(self):
+        """
+        Relative dates should be included even when their actual_date is in the past.
+        """
+        now = timezone.now()
+        # Set up a relative DatePolicy
+        date_policy = DatePolicy.objects.create(rel_date=timedelta(days=-2))
+        content_date = ContentDate.objects.create(
+            course_id=self.course_1.id,
+            location=self.sequential_1.location,
+            active=True,
+            block_type="sequential",
+            field="due",
+            policy=date_policy,
+        )
+        UserDate.objects.create(user=self.user, content_date=content_date)
+
+        self.login_and_enroll(self.course_1.id)
+        response = self.api_response(username=self.user.username)
+
+        results = response.data["results"]
+        self.assertEqual(len(results), 1, "Relative date should be included even if past.")
+
+    def test_course_settings_disable_relative_dates(self):
+        """
+        Dates should be skipped if course settings do not enable relative dates.
+        """
+        now = timezone.now()
+        course = CourseFactory.create(modulestore=self.store, start=timezone.now() - timedelta(weeks=5))
+
+        # Patch course settings to disable relative behavior
+        course = self.store.get_course(course.id)
+        course.self_paced = False
+        course.relative_weeks_due = None
+        self.store.update_item(course, self.user.id)
+
+        chapter = self.make_block("chapter", course)
+        sequential = self.make_block("sequential", chapter)
+        date_policy = DatePolicy.objects.create(rel_date=timedelta(weeks=-3))
+        content_date = ContentDate.objects.create(
+            course_id=course.id,
+            location=sequential.location,
+            active=True,
+            block_type="sequential",
+            field="due",
+            policy=date_policy,
+        )
+        UserDate.objects.create(user=self.user, content_date=content_date)
+
+        self.login_and_enroll(course.id)
+        response = self.api_response(username=self.user.username)
         self.assertListEqual(response.data["results"], [])


### PR DESCRIPTION
### PR Summary
This PR ensures that `AllCourseDatesAPIView` returns not only future dates but also any relative dates provided that the course is set up to use relative dates.