### PR TITLE
fix: [AXM-2791] add missing color

### DIFF
--- a/lms/djangoapps/course_home_api/progress/serializers.py
+++ b/lms/djangoapps/course_home_api/progress/serializers.py
@@ -105,6 +105,7 @@ class GradingPolicySerializer(ReadOnlySerializer):
         "#D13F88",  # Magenta Pink
         "#36A17D",  # Jade Green
         "#AE5AD8",  # Lavender Purple
+        "#3BA03B",  # Forest Green
     ]
 
     assignment_policies = serializers.SerializerMethodField()


### PR DESCRIPTION
### Summary
Add one assignment color that was missing from the initial list of colors.